### PR TITLE
fix: duplicate chat messages on reconnect (#82)

### DIFF
--- a/packages/client/src/__tests__/CommsScreen.test.tsx
+++ b/packages/client/src/__tests__/CommsScreen.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CommsScreen } from '../components/CommsScreen';
+import { useStore } from '../state/store';
 import { mockStoreState } from '../test/mockStore';
 
 vi.mock('../network/client', () => ({
@@ -80,5 +81,25 @@ describe('CommsScreen', () => {
     render(<CommsScreen />);
     await userEvent.click(screen.getByText('[SEND]'));
     expect(network.sendChat).not.toHaveBeenCalled();
+  });
+
+  it('does not display duplicate messages when same id is added twice', () => {
+    const msg = {
+      id: 'dup-1', senderId: 's1', senderName: 'PhashX',
+      channel: 'local' as const, content: 'Duplicate test',
+      sentAt: Date.now(), delayed: false,
+    };
+    mockStoreState({
+      chatMessages: [msg],
+      chatChannel: 'local' as const,
+      alerts: {},
+    });
+
+    // Simulate server sending the same message again (e.g. on reconnect)
+    useStore.getState().addChatMessage(msg);
+
+    render(<CommsScreen />);
+    const matches = screen.getAllByText(/Duplicate test/);
+    expect(matches).toHaveLength(1);
   });
 });

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -306,9 +306,11 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set)
   setCargo: (cargo) => set({ cargo }),
 
   addChatMessage: (msg) =>
-    set((s) => ({
-      chatMessages: [...s.chatMessages.slice(-199), msg],
-    })),
+    set((s) => {
+      // Deduplicate by message ID
+      if (s.chatMessages.some(m => m.id === msg.id)) return s;
+      return { chatMessages: [...s.chatMessages.slice(-199), msg] };
+    }),
   setChatChannel: (chatChannel) => set({ chatChannel }),
   setAlert: (monitorId, active) => set((s) => ({
     alerts: { ...s.alerts, [monitorId]: active },


### PR DESCRIPTION
## Summary
- `addChatMessage` in gameSlice now deduplicates by `msg.id` before appending
- Root cause: on reconnect/sector change, server re-sends `chatHistory` (last 50 messages) which got appended without checking for existing IDs
- Added test: verifying same message ID added twice only appears once

Fixes #82

## Test plan
- [x] New test: duplicate message ID only displays once
- [x] All 136 client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)