### PR TITLE
fix: UI bugs #79, #81, #83, #84, #89

### DIFF
--- a/packages/client/src/canvas/RadarRenderer.ts
+++ b/packages/client/src/canvas/RadarRenderer.ts
@@ -321,7 +321,14 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
     ctx.restore();
   }
 
-  // --- Coordinate frame ---
+  // --- Coordinate frame (tightly wraps actual cells) ---
+  const totalCellsW = (2 * radiusX + 1) * CELL_W;
+  const totalCellsH = (2 * radiusY + 1) * CELL_H;
+  const frameLeft = gridCenterX - totalCellsW / 2;
+  const frameTop = gridCenterY - totalCellsH / 2;
+  const frameRight = gridCenterX + totalCellsW / 2;
+  const frameBottom = gridCenterY + totalCellsH / 2;
+
   ctx.font = COORD_FONT;
   ctx.fillStyle = state.dimColor;
 
@@ -331,7 +338,7 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
   for (let dy = -radiusY; dy <= radiusY; dy++) {
     const sy = viewY + dy;
     const cellY = gridCenterY + dy * CELL_H;
-    ctx.fillText(String(sy), FRAME_LEFT - 8, cellY);
+    ctx.fillText(String(sy), frameLeft - 8, cellY);
   }
 
   // Column labels (bottom) — X galaxy coordinates
@@ -340,17 +347,17 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
   for (let dx = -radiusX; dx <= radiusX; dx++) {
     const sx = viewX + dx;
     const cellX = gridCenterX + dx * CELL_W;
-    ctx.fillText(String(sx), cellX, gridBottom + 4);
+    ctx.fillText(String(sx), cellX, frameBottom + 4);
   }
 
-  // Frame border
+  // Frame border — tightly wraps the cell grid
   ctx.strokeStyle = state.dimColor.replace(/[\d.]+\)$/, '0.5)');
   ctx.lineWidth = 1;
   ctx.beginPath();
-  ctx.moveTo(gridLeft - 1, gridTop - 1);
-  ctx.lineTo(gridRight + 1, gridTop - 1);
-  ctx.lineTo(gridRight + 1, gridBottom + 1);
-  ctx.lineTo(gridLeft - 1, gridBottom + 1);
+  ctx.moveTo(frameLeft - 1, frameTop - 1);
+  ctx.lineTo(frameRight + 1, frameTop - 1);
+  ctx.lineTo(frameRight + 1, frameBottom + 1);
+  ctx.lineTo(frameLeft - 1, frameBottom + 1);
   ctx.closePath();
   ctx.stroke();
 

--- a/packages/client/src/components/CargoScreen.tsx
+++ b/packages/client/src/components/CargoScreen.tsx
@@ -75,7 +75,7 @@ export function CargoScreen() {
   }, []);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '8px 12px' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, overflow: 'auto', padding: '8px 12px' }}>
       <div style={{ fontSize: '0.8rem', letterSpacing: '0.2em', opacity: 0.6, marginBottom: '12px' }}>
         CARGO HOLD
       </div>

--- a/packages/client/src/components/CommsScreen.tsx
+++ b/packages/client/src/components/CommsScreen.tsx
@@ -4,6 +4,8 @@ import { network } from '../network/client';
 import type { ChatChannel } from '@void-sector/shared';
 
 const CHANNELS: ChatChannel[] = ['direct', 'faction', 'local'];
+const MAX_VISIBLE_MESSAGES = 15;
+const MESSAGE_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 export function CommsScreen() {
   const messages = useStore(s => s.chatMessages);
@@ -14,6 +16,19 @@ export function CommsScreen() {
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { clearAlert('COMMS'); }, []);
+
+  // Prune old messages (>2h) periodically
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const current = useStore.getState().chatMessages;
+      const pruned = current.filter(m => now - m.sentAt < MESSAGE_MAX_AGE_MS);
+      if (pruned.length < current.length) {
+        useStore.setState({ chatMessages: pruned });
+      }
+    }, 60_000); // check every minute
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     logRef.current?.scrollTo(0, logRef.current.scrollHeight);
@@ -36,8 +51,8 @@ export function CommsScreen() {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: 8, gap: 8 }}>
-      <div style={{ display: 'flex', gap: 4 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, padding: 8, gap: 8 }}>
+      <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
         {CHANNELS.map(ch => (
           <button key={ch} className="vs-btn"
             style={ch === channel ? { background: 'var(--color-primary)', color: '#000' } : {}}
@@ -48,10 +63,10 @@ export function CommsScreen() {
       </div>
 
       <div ref={logRef} style={{
-        flex: 1, overflow: 'auto', fontSize: '0.8rem',
+        flex: 1, minHeight: 0, overflow: 'auto', fontSize: '0.8rem',
         border: '1px solid var(--color-dim)', padding: 6,
       }}>
-        {filtered.map(msg => (
+        {filtered.slice(-MAX_VISIBLE_MESSAGES).map(msg => (
           <div key={msg.id} style={{ marginBottom: 2 }}>
             <span style={{ color: 'var(--color-dim)' }}>[{formatTime(msg.sentAt, msg.delayed)}]</span>
             {' '}<span style={{ color: 'var(--color-primary)' }}>{msg.senderName}:</span>
@@ -63,7 +78,7 @@ export function CommsScreen() {
         )}
       </div>
 
-      <div style={{ display: 'flex', gap: 4 }}>
+      <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
         <input type="text" value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && send()}

--- a/packages/client/src/components/GameScreen.tsx
+++ b/packages/client/src/components/GameScreen.tsx
@@ -209,7 +209,7 @@ function SchematicView() {
             onChange={(e) => setColorProfile(e.target.value as ColorProfileName)}
             style={{
               display: 'block', marginTop: 4, width: '100%',
-              background: 'transparent', border: '1px solid var(--color-primary)',
+              background: '#050505', border: '1px solid var(--color-primary)',
               color: 'var(--color-primary)', fontFamily: 'var(--font-mono)',
               padding: '4px 8px', fontSize: '0.8rem',
             }}
@@ -294,7 +294,7 @@ function SchematicView() {
           onChange={(e) => setColorProfile(e.target.value as ColorProfileName)}
           style={{
             display: 'block', marginTop: 2, width: '100%',
-            background: 'transparent', border: '1px solid var(--color-primary)',
+            background: '#050505', border: '1px solid var(--color-primary)',
             color: 'var(--color-primary)', fontFamily: 'var(--font-mono)',
             padding: '3px 6px', fontSize: '0.7rem',
           }}

--- a/packages/client/src/styles/crt.css
+++ b/packages/client/src/styles/crt.css
@@ -209,8 +209,10 @@
   z-index: 1;
   width: 100%;
   height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .bezel-bottom {

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -77,6 +77,16 @@ html, body {
   animation: ap-flash 0.4s ease-out;
 }
 
+/* Select/option styling — ensure dark background for all profiles */
+select {
+  background: #050505;
+  color: var(--color-primary);
+}
+select option {
+  background: #050505;
+  color: var(--color-primary);
+}
+
 /* CRT Amber Scrollbars */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: #0a0a0a; border-left: 1px solid rgba(255, 176, 0, 0.1); }


### PR DESCRIPTION
## Summary
- **#79** High Contrast display profile: `<select>`/`<option>` elements now have dark background (`#050505`) with colored text, fixing unreadable white-on-white text
- **#81/#83** Nav UI grid alignment: Frame border now tightly wraps the actual cell grid (computed from cell positions) instead of spanning the full canvas area, eliminating gaps between outermost tiles and frame
- **#84** COM UI: Limits visible messages to 15 with scrolling, auto-prunes messages older than 2h via periodic cleanup interval
- **#89** Sidebar overflow: COM, CRG, LOG monitors now properly constrain content within their sidebar slots using `minHeight: 0` + `overflow: auto`, preventing layout shifts. `.crt-content` also gets `overflow: hidden` + `min-height: 0` for belt-and-suspenders containment

## Test plan
- [x] All 453 tests pass (103 shared + 214 server + 136 client)
- [x] Client type check clean (`tsc --noEmit`)
- [ ] Visual: Switch to High Contrast profile, verify options dropdown is readable
- [ ] Visual: Check nav grid at all zoom levels — tiles should align to frame edges
- [ ] Visual: Open COMMS/CARGO in sidebar, verify no layout shift

Closes #79, #81, #83, #84, #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)