### PR TITLE
feat: reduce QUADRANT_SIZE 10,000→500 with centered coordinate layout (#218/#223)

### DIFF
--- a/docs/compendium.md
+++ b/docs/compendium.md
@@ -17,8 +17,8 @@ Das Universum ist ein unendliches 2D-Gitter. Koordinaten werden zweistellig darg
 [QUAD:INNER]  →  z.B. [03E8:0042]
 ```
 
-- **QUAD** (hex): `Math.floor(x / 10_000)` — Quadrant im Universum
-- **INNER** (dez): `x % 10_000` — Lokale Position im Quadranten
+- **QUAD** (hex): `Math.floor((x + 250) / 500)` — Quadrant im Universum (zentriert, Ursprung in Quadrantmitte)
+- **INNER** (dez): lokale Position im Quadranten, Bereich -250..249
 - Spieler spawnen in **Clustern** ab Distanz `10_000_000` vom Ursprung
 - Cluster-Radius: 300 Sektoren, max. 5 Spieler pro Cluster
 
@@ -74,7 +74,7 @@ Seed-basierte Blob-Generierung fuer grossflaechige Nebel:
 
 ## 2. Quadranten-System
 
-Jeder Quadrant umfasst **10.000 x 10.000** Sektoren (`QUADRANT_SIZE = 10_000`).
+Jeder Quadrant umfasst **500 x 500** Sektoren (`QUADRANT_SIZE = 500`). Das Koordinatensystem ist zentriert: Quadrant (0,0) deckt Sektoren x∈[-250, 249], y∈[-250, 249] ab. Der Ursprung (0,0) liegt in der Mitte von Quadrant (0,0).
 
 ### Erstkontakt-Benennung
 

--- a/packages/client/src/__tests__/QuadrantMapRenderer.test.ts
+++ b/packages/client/src/__tests__/QuadrantMapRenderer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { QUADRANT_SIZE } from '@void-sector/shared';
 import {
   QUAD_CELL_SIZES,
   QUAD_FRAME_LEFT,
@@ -126,26 +127,36 @@ describe('QuadrantMapRenderer', () => {
   });
 
   describe('sectorToQuadrantCoords', () => {
+    // Centered layout: half = floor(QS/2); q0 spans [-half, half-1]
+    const half = Math.floor(QUADRANT_SIZE / 2);
+
     it('converts origin correctly', () => {
       expect(sectorToQuadrantCoords(0, 0)).toEqual({ qx: 0, qy: 0 });
     });
 
     it('converts positive sectors', () => {
-      // QUADRANT_SIZE is 10000
-      expect(sectorToQuadrantCoords(10000, 20000)).toEqual({ qx: 1, qy: 2 });
+      // half is the first sector of q1; QS+half is first of q2
+      expect(sectorToQuadrantCoords(half, 0)).toEqual({ qx: 1, qy: 0 });
+      expect(sectorToQuadrantCoords(QUADRANT_SIZE + half, 0)).toEqual({ qx: 2, qy: 0 });
     });
 
     it('converts negative sectors', () => {
-      expect(sectorToQuadrantCoords(-1, -1)).toEqual({ qx: -1, qy: -1 });
+      // -(half+1) is the first sector of q-1
+      expect(sectorToQuadrantCoords(-(half + 1), -(half + 1))).toEqual({ qx: -1, qy: -1 });
     });
 
     it('converts sectors within a quadrant', () => {
-      expect(sectorToQuadrantCoords(5000, 5000)).toEqual({ qx: 0, qy: 0 });
-      expect(sectorToQuadrantCoords(9999, 9999)).toEqual({ qx: 0, qy: 0 });
+      // -1 and half-1 are both within q0
+      expect(sectorToQuadrantCoords(-1, -1)).toEqual({ qx: 0, qy: 0 });
+      expect(sectorToQuadrantCoords(half - 1, half - 1)).toEqual({ qx: 0, qy: 0 });
     });
 
     it('handles large coordinates', () => {
-      expect(sectorToQuadrantCoords(10_000_000, 10_000_000)).toEqual({ qx: 1000, qy: 1000 });
+      // 1000 * QS sectors from origin → quadrant 1000
+      expect(sectorToQuadrantCoords(1000 * QUADRANT_SIZE, 1000 * QUADRANT_SIZE)).toEqual({
+        qx: 1000,
+        qy: 1000,
+      });
     });
   });
 

--- a/packages/client/src/canvas/QuadrantMapRenderer.ts
+++ b/packages/client/src/canvas/QuadrantMapRenderer.ts
@@ -360,8 +360,9 @@ export function quadrantAtPoint(
  * Convert sector coordinates to quadrant coordinates.
  */
 export function sectorToQuadrantCoords(x: number, y: number): { qx: number; qy: number } {
+  const half = Math.floor(QUADRANT_SIZE / 2);
   return {
-    qx: Math.floor(x / QUADRANT_SIZE),
-    qy: Math.floor(y / QUADRANT_SIZE),
+    qx: Math.floor((x + half) / QUADRANT_SIZE),
+    qy: Math.floor((y + half) / QUADRANT_SIZE),
   };
 }

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -97,7 +97,8 @@ function getWsUrl(): string {
 }
 
 function sectorToQuadrant(x: number, y: number): { qx: number; qy: number } {
-  return { qx: Math.floor(x / QUADRANT_SIZE), qy: Math.floor(y / QUADRANT_SIZE) };
+  const half = Math.floor(QUADRANT_SIZE / 2);
+  return { qx: Math.floor((x + half) / QUADRANT_SIZE), qy: Math.floor((y + half) / QUADRANT_SIZE) };
 }
 
 /** Check if a monitor is currently visible (desktop activeProgram or mobile activeMonitor).

--- a/packages/server/src/engine/__tests__/quadrantEngine.test.ts
+++ b/packages/server/src/engine/__tests__/quadrantEngine.test.ts
@@ -42,30 +42,34 @@ beforeEach(() => {
 // sectorToQuadrant
 // ---------------------------------------------------------------------------
 describe('sectorToQuadrant', () => {
+  // Centered layout: quadrant (0,0) spans x∈[-half, half-1] where half = floor(QS/2)
+  const half = Math.floor(QUADRANT_SIZE / 2);
+
   it('maps positive coordinates correctly', () => {
     expect(sectorToQuadrant(0, 0)).toEqual({ qx: 0, qy: 0 });
-    expect(sectorToQuadrant(9999, 9999)).toEqual({ qx: 0, qy: 0 });
-    expect(sectorToQuadrant(10000, 10000)).toEqual({ qx: 1, qy: 1 });
-    expect(sectorToQuadrant(25000, 15000)).toEqual({ qx: 2, qy: 1 });
+    expect(sectorToQuadrant(half - 1, half - 1)).toEqual({ qx: 0, qy: 0 }); // last of q0
+    expect(sectorToQuadrant(half, half)).toEqual({ qx: 1, qy: 1 });          // first of q1
+    expect(sectorToQuadrant(QUADRANT_SIZE + half, QUADRANT_SIZE)).toEqual({ qx: 2, qy: 1 });
   });
 
   it('maps negative coordinates correctly', () => {
-    expect(sectorToQuadrant(-1, -1)).toEqual({ qx: -1, qy: -1 });
-    expect(sectorToQuadrant(-10000, -10000)).toEqual({ qx: -1, qy: -1 });
-    expect(sectorToQuadrant(-10001, -10001)).toEqual({ qx: -2, qy: -2 });
+    expect(sectorToQuadrant(-1, -1)).toEqual({ qx: 0, qy: 0 });                         // still in q0
+    expect(sectorToQuadrant(-half, -half)).toEqual({ qx: 0, qy: 0 });                   // left edge of q0
+    expect(sectorToQuadrant(-(half + 1), -(half + 1))).toEqual({ qx: -1, qy: -1 });     // first in q-1
   });
 
   it('handles boundary values', () => {
-    // Right at the boundary: QUADRANT_SIZE should be in the next quadrant
+    // half is the first sector of q1
     expect(sectorToQuadrant(QUADRANT_SIZE, 0)).toEqual({ qx: 1, qy: 0 });
     expect(sectorToQuadrant(0, QUADRANT_SIZE)).toEqual({ qx: 0, qy: 1 });
-    // Just below boundary
-    expect(sectorToQuadrant(QUADRANT_SIZE - 1, QUADRANT_SIZE - 1)).toEqual({ qx: 0, qy: 0 });
+    expect(sectorToQuadrant(half - 1, 0)).toEqual({ qx: 0, qy: 0 });
+    expect(sectorToQuadrant(half, 0)).toEqual({ qx: 1, qy: 0 });
   });
 
   it('handles mixed positive/negative', () => {
-    expect(sectorToQuadrant(15000, -5000)).toEqual({ qx: 1, qy: -1 });
-    expect(sectorToQuadrant(-15000, 5000)).toEqual({ qx: -2, qy: 0 });
+    // q2 starts at QS+half; q-1 starts at -(half+1)
+    expect(sectorToQuadrant(QUADRANT_SIZE + half, -(half + 1))).toEqual({ qx: 2, qy: -1 });
+    expect(sectorToQuadrant(-(half + 1), QUADRANT_SIZE + half)).toEqual({ qx: -1, qy: 2 });
   });
 });
 

--- a/packages/server/src/engine/__tests__/quadrantHandlers.test.ts
+++ b/packages/server/src/engine/__tests__/quadrantHandlers.test.ts
@@ -69,9 +69,10 @@ function makeQuadrant(overrides: Partial<QuadrantData> = {}): QuadrantData {
 // ---------------------------------------------------------------------------
 describe('first-contact detection logic', () => {
   it('detects new quadrant when sector coordinates cross quadrant boundary', () => {
-    // Sector 9999 is in quadrant 0, sector 10000 is in quadrant 1
-    const origin = sectorToQuadrant(9999, 0);
-    const target = sectorToQuadrant(10000, 0);
+    // Centered layout: last sector of q0 is half-1, first of q1 is half
+    const half = Math.floor(QUADRANT_SIZE / 2);
+    const origin = sectorToQuadrant(half - 1, 0);
+    const target = sectorToQuadrant(half, 0);
     expect(origin.qx).toBe(0);
     expect(target.qx).toBe(1);
     // Different quadrants -> first contact should trigger
@@ -90,8 +91,10 @@ describe('first-contact detection logic', () => {
   });
 
   it('detects quadrant change on negative boundary crossing', () => {
-    const origin = sectorToQuadrant(0, 0);
-    const target = sectorToQuadrant(-1, 0);
+    // Centered layout: q0 left boundary is -half; -(half+1) is in q-1
+    const half = Math.floor(QUADRANT_SIZE / 2);
+    const origin = sectorToQuadrant(-half, 0);
+    const target = sectorToQuadrant(-(half + 1), 0);
     expect(origin.qx).toBe(0);
     expect(target.qx).toBe(-1);
     expect(origin.qx !== target.qx).toBe(true);
@@ -322,28 +325,34 @@ describe('syncQuadrants logic', () => {
 // Quadrant boundary edge cases
 // ---------------------------------------------------------------------------
 describe('quadrant boundary edge cases', () => {
+  const half = Math.floor(QUADRANT_SIZE / 2);
+
   it('large positive coordinates map to correct quadrant', () => {
-    const result = sectorToQuadrant(50000, 30000);
-    expect(result.qx).toBe(5);
-    expect(result.qy).toBe(3);
+    // 100 * QS sectors from origin → quadrant 100
+    const result = sectorToQuadrant(100 * QUADRANT_SIZE, 60 * QUADRANT_SIZE);
+    expect(result.qx).toBe(100);
+    expect(result.qy).toBe(60);
   });
 
   it('large negative coordinates map to correct quadrant', () => {
-    const result = sectorToQuadrant(-50001, -30001);
-    expect(result.qx).toBe(-6);
-    expect(result.qy).toBe(-4);
+    // -(100 * QS + 1) → quadrant -100 (floor((-100*QS-1+half)/QS) = -100)
+    const result = sectorToQuadrant(-(100 * QUADRANT_SIZE + 1), -(60 * QUADRANT_SIZE + 1));
+    expect(result.qx).toBe(-100);
+    expect(result.qy).toBe(-60);
   });
 
   it('exactly at QUADRANT_SIZE boundary', () => {
+    // QS is the first sector of q1 for centered formula (floor((QS+half)/QS)=1)
     const result = sectorToQuadrant(QUADRANT_SIZE, QUADRANT_SIZE);
     expect(result.qx).toBe(1);
     expect(result.qy).toBe(1);
   });
 
-  it('one less than QUADRANT_SIZE', () => {
+  it('QUADRANT_SIZE-1 is in quadrant 1 with centered layout', () => {
+    // Centered q1 spans [half, QS+half-1]. QS-1 >= half for any QS>1.
     const result = sectorToQuadrant(QUADRANT_SIZE - 1, QUADRANT_SIZE - 1);
-    expect(result.qx).toBe(0);
-    expect(result.qy).toBe(0);
+    expect(result.qx).toBe(1);
+    expect(result.qy).toBe(1);
   });
 
   it('origin sector is in quadrant (0,0)', () => {
@@ -352,9 +361,10 @@ describe('quadrant boundary edge cases', () => {
     expect(result.qy).toBe(0);
   });
 
-  it('sector (-1, -1) is in quadrant (-1, -1)', () => {
+  it('sector (-1, -1) is in quadrant (0,0) with centered layout', () => {
+    // Centered q0 spans [-half, half-1]; -1 is within q0 (half >= 1)
     const result = sectorToQuadrant(-1, -1);
-    expect(result.qx).toBe(-1);
-    expect(result.qy).toBe(-1);
+    expect(result.qx).toBe(0);
+    expect(result.qy).toBe(0);
   });
 });

--- a/packages/server/src/engine/__tests__/scanEvents.test.ts
+++ b/packages/server/src/engine/__tests__/scanEvents.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { checkScanEvent, getEffectiveEventChance } from '../scanEvents.js';
+import { QUADRANT_SIZE } from '@void-sector/shared';
 
 describe('scanEvents', () => {
   it('checkScanEvent is deterministic', () => {
@@ -84,24 +85,27 @@ describe('scanEvents', () => {
   });
 
   describe('getEffectiveEventChance', () => {
+    // Origin (0,0) is at center of q0 with centered layout → far from any edge
+    // Sector at (half, 0) is exactly at the q0/q1 boundary → nearEdge
+    const half = Math.floor(QUADRANT_SIZE / 2);
+
     it('empty sectors far from edges have lowest chance', () => {
-      const chance = getEffectiveEventChance('empty', 5000, 5000);
+      const chance = getEffectiveEventChance('empty', 0, 0);
       expect(chance).toBe(0.012);
     });
 
     it('empty sectors near quadrant edge have higher chance', () => {
-      // x=100 is near edge (within 500 of quadrant boundary at 0)
-      const chance = getEffectiveEventChance('empty', 100, 5000);
+      const chance = getEffectiveEventChance('empty', half, 0);
       expect(chance).toBe(0.03);
     });
 
     it('nebula sectors have high chance', () => {
-      const chance = getEffectiveEventChance('nebula', 5000, 5000);
+      const chance = getEffectiveEventChance('nebula', 0, 0);
       expect(chance).toBe(0.3);
     });
 
     it('nebula at quadrant edges has very high chance', () => {
-      const chance = getEffectiveEventChance('nebula', 100, 5000);
+      const chance = getEffectiveEventChance('nebula', half, 0);
       expect(chance).toBe(0.95);
     });
   });

--- a/packages/server/src/engine/quadrantEngine.ts
+++ b/packages/server/src/engine/quadrantEngine.ts
@@ -19,9 +19,10 @@ import {
 // --------------------------------------------------------------------------
 
 export function sectorToQuadrant(x: number, y: number): { qx: number; qy: number } {
+  const half = Math.floor(QUADRANT_SIZE / 2);
   return {
-    qx: Math.floor(x / QUADRANT_SIZE),
-    qy: Math.floor(y / QUADRANT_SIZE),
+    qx: Math.floor((x + half) / QUADRANT_SIZE),
+    qy: Math.floor((y + half) / QUADRANT_SIZE),
   };
 }
 

--- a/packages/server/src/engine/scanEvents.ts
+++ b/packages/server/src/engine/scanEvents.ts
@@ -26,11 +26,12 @@ const EVENT_TYPE_WEIGHTS: { type: ScanEventType; weight: number; immediate: bool
   { type: 'blueprint_find', weight: 0.1, immediate: false },
 ];
 
-/** Distance from nearest quadrant edge (0 = at edge) */
+/** Distance from nearest quadrant edge (0 = at edge). Uses centered quadrant layout. */
 function quadrantEdgeDistance(x: number, y: number): number {
-  const modX = ((x % QUADRANT_SIZE) + QUADRANT_SIZE) % QUADRANT_SIZE;
-  const modY = ((y % QUADRANT_SIZE) + QUADRANT_SIZE) % QUADRANT_SIZE;
-  return Math.min(modX, QUADRANT_SIZE - modX, modY, QUADRANT_SIZE - modY);
+  const half = Math.floor(QUADRANT_SIZE / 2);
+  const posX = ((x + half) % QUADRANT_SIZE + QUADRANT_SIZE) % QUADRANT_SIZE;
+  const posY = ((y + half) % QUADRANT_SIZE + QUADRANT_SIZE) % QUADRANT_SIZE;
+  return Math.min(posX, QUADRANT_SIZE - posX, posY, QUADRANT_SIZE - posY);
 }
 
 /**
@@ -48,7 +49,7 @@ export function getEffectiveEventChance(
   y: number,
 ): number {
   const edgeDist = quadrantEdgeDistance(x, y);
-  const nearEdge = edgeDist < 500;
+  const nearEdge = edgeDist < 50;
 
   if (environment === 'nebula') {
     return nearEdge ? 0.95 : 0.3;

--- a/packages/server/src/engine/universeSeedingService.ts
+++ b/packages/server/src/engine/universeSeedingService.ts
@@ -139,8 +139,9 @@ export function generateQuadrantData(
 ): { environments: SectorEnvironmentRecord[]; contents: SectorContentRecord[] } {
   const environments: SectorEnvironmentRecord[] = [];
   const contents: SectorContentRecord[] = [];
-  const baseX = quadrantX * QUADRANT_SIZE;
-  const baseY = quadrantY * QUADRANT_SIZE;
+  const half = Math.floor(QUADRANT_SIZE / 2);
+  const baseX = quadrantX * QUADRANT_SIZE - half;
+  const baseY = quadrantY * QUADRANT_SIZE - half;
 
   for (let sx = 0; sx < QUADRANT_SIZE; sx++) {
     for (let sy = 0; sy < QUADRANT_SIZE; sy++) {

--- a/packages/shared/src/__tests__/quadrant.test.ts
+++ b/packages/shared/src/__tests__/quadrant.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { QUADRANT_SIZE, QUADRANT_NAME_MAX_LENGTH, QUADRANT_NAME_MIN_LENGTH } from '../constants';
 
 describe('Quadrant constants', () => {
-  it('QUADRANT_SIZE is 10000', () => {
-    expect(QUADRANT_SIZE).toBe(10_000);
+  it('QUADRANT_SIZE is 500', () => {
+    expect(QUADRANT_SIZE).toBe(500);
   });
   it('name length constraints are valid', () => {
     expect(QUADRANT_NAME_MIN_LENGTH).toBeLessThan(QUADRANT_NAME_MAX_LENGTH);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1713,11 +1713,15 @@ export const AUTOPILOT_STEP_MS = 100; // ms per sector during autopilot
 export const STALENESS_DIM_HOURS = 24; // dim sectors after 24h
 export const STALENESS_FADE_DAYS = 7; // coords-only after 7 days
 
-export const QUADRANT_SIZE = 10_000;
+export const QUADRANT_SIZE = 500;
 
-/** Convert absolute coordinate to inner sector coordinate (0..QUADRANT_SIZE-1) */
+/**
+ * Convert absolute coordinate to inner sector coordinate (-half..half-1).
+ * Origin (0) is at center of quadrant (0,0). Range: [-250, 249].
+ */
 export function innerCoord(abs: number): number {
-  return ((abs % QUADRANT_SIZE) + QUADRANT_SIZE) % QUADRANT_SIZE;
+  const half = Math.floor(QUADRANT_SIZE / 2);
+  return abs - Math.floor((abs + half) / QUADRANT_SIZE) * QUADRANT_SIZE;
 }
 export const SPAWN_QUADRANT_DISTANCE = 10_000_000;
 export const SPAWN_QUADRANT_BAND = 10;


### PR DESCRIPTION
## Summary

- **QUADRANT_SIZE**: 10,000 → 500 sectors per quadrant side
- **Centered coordinates**: Quadrant (0,0) now spans x∈[-250, 249], y∈[-250, 249] — origin (0,0) is at the center of q(0,0), not the corner
- **`innerCoord(abs)`**: New formula returns range [-250, 249] instead of [0, 9999]
- **`sectorToQuadrant`**: `Math.floor((x + half) / QS)` — consistent on server, client renderer, and network client
- **`scanEvents`**: Edge distance formula updated for centered layout; `nearEdge` threshold 500→50 (10% of new QS)
- **`universeSeedingService`**: `baseX/Y` uses centered offset so q(0,0) seeds sectors [-250,-250]→[249,249]
- **Compendium**: Updated quadrant size description

## Test Plan

- [x] Server tests: 1108/1109 pass (1 pre-existing DB connection failure unrelated)
- [x] Client tests: 545/545 pass
- [x] Shared tests: 205/205 pass
- [x] All quadrant boundary tests updated to use dynamic `half = floor(QS/2)` for portability
- [ ] Verify in-game: cross-quadrant moves trigger first-contact at the right boundary
- [ ] Verify quadrant map renders correct quadrant names at current position

Closes #218
Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)