### PR TITLE
fix: clamp ResourceBar filled to prevent repeat(-1) crash in anomaly mineAll

### DIFF
--- a/packages/client/src/__tests__/MiningScreen.test.tsx
+++ b/packages/client/src/__tests__/MiningScreen.test.tsx
@@ -151,4 +151,23 @@ describe('MiningScreen', () => {
     render(<MiningScreen />);
     expect(screen.getByText(/status\.idle/)).toBeInTheDocument();
   });
+
+  it('does not crash when resource value exceeds maxResource (anomaly mineAll race condition)', () => {
+    // Anomaly: ore=5 but maxOre=3 (can happen during mineAll chain transition)
+    // Without clamping, filled=17 → repeat(-7) → RangeError
+    mockStoreState({
+      currentSector: {
+        x: 0, y: 0,
+        type: 'anomaly' as const,
+        seed: 42,
+        discoveredBy: null,
+        discoveredAt: null,
+        metadata: {},
+        environment: 'empty' as const,
+        contents: ['anomaly' as const],
+        resources: { ore: 5, gas: 3, crystal: 20, maxOre: 3, maxGas: 3, maxCrystal: 20 },
+      },
+    });
+    expect(() => render(<MiningScreen />)).not.toThrow();
+  });
 });

--- a/packages/client/src/components/MiningScreen.tsx
+++ b/packages/client/src/components/MiningScreen.tsx
@@ -10,7 +10,7 @@ import { InlineError } from './InlineError';
 function ResourceBar({ label, value, max, maxResource }: { label: string; value: number; max: number; maxResource?: number }) {
   const width = 10;
   const displayMax = maxResource ?? max;
-  const filled = displayMax > 0 ? Math.round((value / displayMax) * width) : 0;
+  const filled = displayMax > 0 ? Math.max(0, Math.min(Math.round((value / displayMax) * width), width)) : 0;
   const bar = '\u2587'.repeat(filled) + '\u2591'.repeat(width - filled);
   return (
     <div style={{ fontFamily: 'var(--font-mono)', fontSize: '0.9rem' }}>


### PR DESCRIPTION
## Summary
- `ResourceBar.filled` was not clamped to `[0, width]`
- During `mineAll` in an anomaly sector (all 3 resources), the live countdown can briefly show `value > maxResource`, making `filled > width` → `width - filled < 0` → `String.repeat(-1)` → `RangeError` → Screen 2 crash
- Fix: wrap with `Math.max(0, Math.min(..., width))`

## Test plan
- [ ] Added regression test: anomaly sector with `ore=5` but `maxOre=3` — renders without throwing
- [ ] `cd packages/client && npx vitest run MiningScreen` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)