### PR TITLE
fix: scan crash + quest Sec3 panel + quest dialog all-expand

### DIFF
--- a/packages/client/src/components/QuestsScreen.tsx
+++ b/packages/client/src/components/QuestsScreen.tsx
@@ -533,6 +533,7 @@ export function QuestsScreen() {
   const navReturnProgram = useStore((s) => s.navReturnProgram);
   const setActiveProgram = useStore((s) => s.setActiveProgram);
   const clearNavReturn = useStore((s) => s.clearNavReturn);
+  const setSelectedQuest = useStore((s) => s.setSelectedQuest);
   const { confirm, isArmed, disarm } = useConfirm(null);
 
   const [tab, setTab] = useState<'auftraege' | 'verfuegbar' | 'reputation' | 'story'>('auftraege');
@@ -680,9 +681,9 @@ export function QuestsScreen() {
                       overflow: 'hidden',
                     }}
                   >
-                    {/* Header row — click to expand */}
+                    {/* Header row — click to expand and select for Sec 3 detail */}
                     <div
-                      onClick={() => setExpandedQuestId(isExpanded ? null : q.id)}
+                      onClick={() => { setExpandedQuestId(isExpanded ? null : q.id); setSelectedQuest(isExpanded ? null : q.id); }}
                       style={{
                         padding: '4px 6px',
                         cursor: 'pointer',
@@ -913,11 +914,12 @@ export function QuestsScreen() {
               <div style={{ color: '#FFB000', marginTop: '8px', marginBottom: '4px' }}>
                 AVAILABLE QUESTS:
               </div>
-              {availableQuests.map((q) => {
-                const armed = isArmed(`accept-${q.templateId}`);
+              {availableQuests.map((q, idx) => {
+                const armKey = `accept-${idx}-${q.templateId}`;
+                const armed = isArmed(armKey);
                 return (
                   <div
-                    key={q.templateId}
+                    key={`${idx}-${q.templateId}`}
                     style={{
                       border: `1px solid ${armed ? 'rgba(0,255,136,0.6)' : 'rgba(255,176,0,0.3)'}`,
                       padding: '4px',
@@ -987,7 +989,7 @@ export function QuestsScreen() {
                       </div>
                     ) : (
                       <button
-                        onClick={() => confirm(`accept-${q.templateId}`, () => network.sendAcceptQuest(q.templateId, position.x, position.y))}
+                        onClick={() => confirm(armKey, () => network.sendAcceptQuest(q.templateId, position.x, position.y))}
                         style={{
                           background: '#1a1a1a',
                           color: '#00FF88',

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -370,6 +370,10 @@ class GameNetwork {
       }) => {
         const store = useStore.getState();
         store.setScanPending(false);
+        if ((data as any).error) {
+          store.setActionError((data as any).error);
+          return;
+        }
         if (store.currentSector) {
           const updatedSector = { ...store.currentSector, resources: data.resources };
           store.setCurrentSector(updatedSector);

--- a/packages/server/src/rooms/services/ScanService.ts
+++ b/packages/server/src/rooms/services/ScanService.ts
@@ -88,7 +88,12 @@ export class ScanService {
     const auth = client.auth as AuthPayload;
     const ap = await getAPState(auth.userId);
     const currentAP = calculateCurrentAP(ap, Date.now());
-    const scannerLevel = this.ctx.getShipForClient(client.sessionId).scannerLevel;
+    const ship = this.ctx.getShipForClient(client.sessionId);
+    if (!ship) {
+      client.send('error', { code: 'SHIP_NOT_READY', message: 'Ship not ready — try again' });
+      return;
+    }
+    const scannerLevel = ship.scannerLevel;
 
     const result = validateLocalScan(currentAP, AP_COSTS_LOCAL_SCAN, scannerLevel);
     if (!result.valid) {


### PR DESCRIPTION
## Summary
Fixes from playtest #309.

- **CRITICAL**: `localScanResult` handler crashed with `TypeError: Cannot read properties of undefined (reading 'ore')` when server sent `{ error: 'Server error' }` without a `resources` field. Client now guards against this and shows the error as an `actionError`.
- **SERVER**: `ScanService.handleLocalScan` threw when `getShipForClient` returned undefined (ship not yet loaded in new sector room). Now sends a clean `SHIP_NOT_READY` error instead.
- **HIGH**: `setSelectedQuest` was never called on quest click in the AKTIV tab — Sec 3 always showed "SELECT A QUEST". Fixed by calling it alongside `setExpandedQuestId`.
- **MEDIUM**: `availableQuests` used `templateId` as React key and confirm key — multiple NPCs offering the same quest template caused all cards to arm simultaneously. Fixed with index-based `armKey`.

Closes #309

## Test plan
- [x] LOCAL SCAN verified: no crash at empty/anomaly sectors, clean error display
- [x] Quest Sec 3 panel: clicking AKTIV quest shows details
- [x] Quest dialog: only clicked card expands
- [x] Re-tested post-Docker-rebuild, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)