### PR TITLE
fix: station UX bugs from playtest #312

### DIFF
--- a/packages/client/src/components/TradeScreen.tsx
+++ b/packages/client/src/components/TradeScreen.tsx
@@ -48,6 +48,7 @@ export function TradeScreen() {
   const navReturnProgram = useStore((s) => s.navReturnProgram);
   const setActiveProgram = useStore((s) => s.setActiveProgram);
   const clearNavReturn = useStore((s) => s.clearNavReturn);
+  const openStationTerminal = useStore((s) => s.openStationTerminal);
   const tradeMessage = useStore((s) => s.tradeMessage);
   const setTradeMessage = useStore((s) => s.setTradeMessage);
   const [amount, setAmount] = useState(1);
@@ -204,10 +205,31 @@ export function TradeScreen() {
                   borderBottom: '1px solid var(--color-dim)',
                   paddingBottom: '4px',
                   marginBottom: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
                 }}
               >
-                {npcStationData.name.toUpperCase()} LV.{npcStationData.level} — XP:{' '}
-                {npcStationData.xp}/{npcStationData.nextLevelXp}
+                <span>
+                  {npcStationData.name.toUpperCase()} LV.{npcStationData.level} — XP:{' '}
+                  {npcStationData.xp}/{npcStationData.nextLevelXp}
+                </span>
+                <button
+                  style={{
+                    ...btnStyle,
+                    fontSize: '0.65rem',
+                    borderColor: '#00FF88',
+                    color: '#00FF88',
+                    whiteSpace: 'nowrap',
+                  }}
+                  onClick={openStationTerminal}
+                >
+                  [ANDOCKEN]
+                </button>
+              </div>
+              <div style={{ fontSize: '0.6rem', opacity: 0.45, marginBottom: 6, letterSpacing: '0.05em' }}>
+                * Preise dynamisch (abhängig vom Lagerbestand)
               </div>
               <div
                 style={{

--- a/packages/server/src/db/npcStationQueries.ts
+++ b/packages/server/src/db/npcStationQueries.ts
@@ -174,15 +174,23 @@ export async function updateStationFuelStock(
   );
 }
 
-/** Decrements gas stock by amount. Does nothing if gas stock is already 0. */
+/** Decrements gas stock by amount, applying lazy restock first. Does nothing if gas stock is already 0. */
 export async function consumeStationGas(
   x: number,
   y: number,
   amount: number,
 ): Promise<void> {
+  // Apply lazy restock before consuming: gas regenerates over time based on restock_rate.
+  // This prevents gas from staying at 0 indefinitely — it refills naturally when not being consumed.
   await query(
     `UPDATE npc_station_inventory
-     SET stock = GREATEST(0, stock - $4), last_updated = NOW()
+     SET stock = GREATEST(0,
+       LEAST(max_stock,
+         stock + (restock_rate - consumption_rate) *
+           EXTRACT(EPOCH FROM (NOW() - last_updated::timestamptz)) / 3600.0
+       ) - $4
+     ),
+     last_updated = NOW()
      WHERE station_x = $1 AND station_y = $2 AND item_type = $3`,
     [x, y, 'gas', amount],
   );

--- a/packages/server/src/engine/npcStationEngine.ts
+++ b/packages/server/src/engine/npcStationEngine.ts
@@ -111,10 +111,11 @@ export async function initStationInventory(x: number, y: number, maxStock: numbe
     const startRatio = 0.5 + fraction * 0.3; // 0.5..0.8
     const startStock = Math.round(maxStock * startRatio);
 
-    // Restock and consumption rates: restock slightly > consumption so stations
-    // tend to slowly fill up when left alone.
-    const baseRestock = maxStock * 0.02; // 2% of max per hour
-    const baseConsumption = maxStock * 0.015; // 1.5% of max per hour
+    // Gas restocks at ~360/hour so the lazy-restock in consumeStationGas keeps up
+    // with the fuel engine's consumption rate (1 gas per 10s = 360/hour).
+    // Ore/crystal use the slower default rates.
+    const restockRate = res === 'gas' ? 360 : maxStock * 0.02;
+    const consumptionRate = res === 'gas' ? 0 : maxStock * 0.015;
 
     await upsertInventoryItem({
       stationX: x,
@@ -122,8 +123,8 @@ export async function initStationInventory(x: number, y: number, maxStock: numbe
       itemType: res,
       stock: startStock,
       maxStock,
-      restockRate: baseRestock,
-      consumptionRate: baseConsumption,
+      restockRate,
+      consumptionRate,
       lastUpdated: now,
     });
   }


### PR DESCRIPTION
## Summary
- **GAS boost always 0**: `consumeStationGas` now applies lazy restock before deducting; gas `restockRate` set to 360/hr to match fuel engine consumption (1 gas/10s) — gas stays at stable levels over time
- **ANDOCKEN not discoverable**: `[ANDOCKEN]` button added directly to TradeScreen header when at a station — no longer requires Sec 3 detail panel navigation
- **Dynamic pricing undisclosed**: note added below station header in TradeScreen NPC tab indicating prices vary by stock level

## Test plan
- [ ] Start fresh server, visit a station — GAS should show > 0 at all times (restocks at ~1/10s)
- [ ] Open TRADE at a station — `[ANDOCKEN]` button visible in header
- [ ] Dynamic pricing note visible in NPC tab when at station
- [ ] All 1402+ server tests pass, 534 client tests pass

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)