### PR TITLE
fix: help tooltip click-to-close not working

### DIFF
--- a/packages/client/src/components/HelpOverlay.tsx
+++ b/packages/client/src/components/HelpOverlay.tsx
@@ -104,7 +104,7 @@ export function HelpOverlay() {
       }}
     >
       <div
-        onClick={(e) => e.stopPropagation()}
+        onClick={dismissTip}
         style={{
           background: 'rgba(0, 0, 0, 0.92)',
           border: '1px solid var(--color-primary)',
@@ -142,7 +142,8 @@ export function HelpOverlay() {
         {activeTip.articleId && (
           <div style={{ marginTop: '10px' }}>
             <button
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation();
                 openCompendium(activeTip.articleId);
               }}
               data-testid="compendium-link"


### PR DESCRIPTION
## Summary
- Clicking the help tooltip card now dismisses it (as the "KLICK zum Schliessen" hint implies)
- Previously the inner card div stopped propagation, preventing click-dismiss from working
- Compendium link button still stops propagation to avoid double-action

## Test plan
- [ ] Trigger a help tip (e.g., enter an asteroid field for the first time)
- [ ] Click anywhere on the tooltip card — it should dismiss
- [ ] ESC still works to dismiss
- [ ] Clicking the compendium link opens the compendium without also closing the tip

Found in playtest #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)