### PR TITLE
fix: bookmark label + quadrant-change log entry (#224)

### DIFF
--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -992,7 +992,7 @@ export function DetailPanel() {
                   freeSlot,
                   selectedSector.x,
                   selectedSector.y,
-                  sector?.type || '',
+                  `${(sector?.type || 'sector').toUpperCase()} (${selectedSector.x},${selectedSector.y})`,
                 );
               }
             }}

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -1637,8 +1637,14 @@ class GameNetwork {
 
     room.onMessage('quadrantInfo', (data: { qx: number; qy: number; name?: string | null }) => {
       const store = useStore.getState();
+      const prev = store.currentQuadrant;
       store.setCurrentQuadrant(data);
       store.addToStatSet('quadrantsVisited', `${data.qx}:${data.qy}`);
+      // Notify player when crossing into a new quadrant
+      if (prev && (prev.qx !== data.qx || prev.qy !== data.qy)) {
+        const label = data.name ? `${data.name} [${data.qx}:${data.qy}]` : `[${data.qx}:${data.qy}]`;
+        store.addLogEntry(`[NAV] Quadrant gewechselt: ${label}`);
+      }
     });
 
     room.onMessage('firstContact', (data: FirstContactEvent) => {


### PR DESCRIPTION
## Summary
- **Bookmark label missing coords**: label was just `sector.type` (e.g. "EMPTY"), now includes coordinates: "EMPTY (21,0)" — multiple bookmarks of same type are distinguishable
- **No feedback on quadrant crossing**: added LOG entry "[NAV] Quadrant gewechselt: [1:0]" when the player crosses into a new quadrant room

Found in automated playtest #224.

## Test plan
- [ ] Set bookmark on an empty sector → label shows "EMPTY (x,y)" in bookmark bar
- [ ] Set two bookmarks on different empty sectors → both are distinguishable
- [ ] Travel 250+ sectors to reach quadrant boundary → LOG shows "Quadrant gewechselt" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)