### PR TITLE
fix: wissen never pushed to client + admin cargo batch (#321)

### DIFF
--- a/packages/server/src/adminRoutes.ts
+++ b/packages/server/src/adminRoutes.ts
@@ -152,24 +152,40 @@ adminRouter.patch('/players/:id/credits', async (req: Request, res: Response) =>
 
 adminRouter.patch('/players/:id/cargo', async (req: Request, res: Response) => {
   try {
-    const { resource, amount } = req.body;
-    if (typeof resource !== 'string' || !resource) {
-      res.status(400).json({ error: 'resource must be a non-empty string' });
-      return;
+    // Accept either { resource, amount } (single) or { items: [...] } (batch)
+    type ItemEntry = { itemType?: string; itemId?: string; resource?: string; quantity?: number; amount?: number };
+    const items: ItemEntry[] = Array.isArray(req.body.items)
+      ? req.body.items
+      : [{ resource: req.body.resource, amount: req.body.amount }];
+
+    // Validate all items before hitting the DB
+    const cargoUpdate: Record<string, number> = {};
+    for (const item of items) {
+      const resource = item.itemId ?? item.resource ?? '';
+      const amount = item.quantity ?? item.amount ?? 0;
+      if (typeof resource !== 'string' || !resource) {
+        res.status(400).json({ error: 'Each item must have a resource/itemId string' });
+        return;
+      }
+      if (typeof amount !== 'number' || amount < 0) {
+        res.status(400).json({ error: 'Each item must have a non-negative quantity/amount' });
+        return;
+      }
+      cargoUpdate[resource] = Math.round(amount);
     }
-    if (typeof amount !== 'number' || amount < 0) {
-      res.status(400).json({ error: 'amount must be a non-negative number' });
-      return;
-    }
+
     const player = await getPlayerById(req.params.id as string);
     if (!player) {
       res.status(404).json({ error: 'Player not found' });
       return;
     }
-    await adminSetCargoItem(req.params.id as string, resource, Math.round(amount));
-    const cargoUpdate: Record<string, number> = { [resource]: Math.round(amount) };
+
+    for (const [resource, amount] of Object.entries(cargoUpdate)) {
+      await adminSetCargoItem(req.params.id as string, resource, amount);
+    }
+
     adminBus.playerUpdated({ playerId: req.params.id as string, updates: { cargo: cargoUpdate } });
-    await logAdminEvent('set_player_cargo', { playerId: req.params.id, resource, amount });
+    await logAdminEvent('set_player_cargo', { playerId: req.params.id, items: cargoUpdate });
     res.json({ ok: true });
   } catch (err) {
     logger.error({ err }, 'Admin set player cargo error');

--- a/packages/server/src/engine/wissenService.ts
+++ b/packages/server/src/engine/wissenService.ts
@@ -1,5 +1,6 @@
+import type { Client } from 'colyseus';
 import { LAB_WISSEN_MULTIPLIER } from '@void-sector/shared';
-import { addWissen, getResearchLabTier } from '../db/queries.js';
+import { addWissen, getResearchLabTier, getWissen } from '../db/queries.js';
 
 /**
  * Award Wissen for a gameplay action, applying lab multiplier.
@@ -12,4 +13,19 @@ export async function awardWissen(playerId: string, baseAmount: number): Promise
   if (gain > 0) {
     await addWissen(playerId, gain);
   }
+}
+
+/**
+ * Award Wissen and immediately push `wissenUpdate` to the client so the
+ * ACEP path-buttons enable without requiring a room rejoin.
+ */
+export function awardWissenAndNotify(
+  client: Client,
+  playerId: string,
+  baseAmount: number,
+): void {
+  awardWissen(playerId, baseAmount)
+    .then(() => getWissen(playerId))
+    .then((wissen) => client.send('wissenUpdate', { wissen }))
+    .catch(() => {});
 }

--- a/packages/server/src/rooms/services/CombatService.ts
+++ b/packages/server/src/rooms/services/CombatService.ts
@@ -5,7 +5,7 @@ import type { CombatState, RoundInput, EnemyModule } from '../../engine/combatTy
 
 import { addAcepXpForPlayer, getAcepXpSummary } from '../../engine/acepXpService.js';
 import { getAcepEffects } from '../../engine/acepXpService.js';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { calculateTraits } from '../../engine/traitCalculator.js';
 import { getPersonalityComment } from '../../engine/personalityMessages.js';
 import { destroyShipAndCreateLegacy, ejectPod } from '../../engine/permadeathService.js';
@@ -257,7 +257,7 @@ export class CombatService {
       addAcepXpForPlayer(playerId, 'kampf', 10).catch(() => {});
       this._emitPersonalityComment(client, playerId, 'combat_victory').catch(() => {});
       const npcWissen = Math.min(8, Math.max(3, Math.ceil(state.enemyLevel / 2)));
-      awardWissen(playerId, npcWissen).catch(() => {});  // +3-8 depending on enemy strength
+      awardWissenAndNotify(client, playerId, npcWissen);  // +3-8 depending on enemy strength
 
       client.send('logEntry', `SIEG! ${state.enemyType} besiegt. +${loot.credits ?? 0} CR`);
     } else if (outcome === 'defeat') {

--- a/packages/server/src/rooms/services/MiningService.ts
+++ b/packages/server/src/rooms/services/MiningService.ts
@@ -11,7 +11,7 @@ import { MINING_RATE_PER_SECOND } from '@void-sector/shared';
 
 import { validateMine, validateJettison } from '../../engine/commands.js';
 import { addAcepXpForPlayer } from '../../engine/acepXpService.js';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { stopMining } from '../../engine/mining.js';
 import { getMiningState, saveMiningState, getMiningStoryCounter, setMiningStoryCounter } from './RedisAPStore.js';
 import { getSector, updateSectorResources, getMiningStoryIndex, updateMiningStoryIndex } from '../../db/queries.js';
@@ -118,7 +118,7 @@ export class MiningService {
       if (miningXp > 0) {
         addAcepXpForPlayer(playerId, 'ausbau', miningXp).catch(() => {});
       }
-      awardWissen(playerId, 1).catch(() => {});  // +1 per mining load
+      awardWissenAndNotify(client, playerId, 1);  // +1 per mining load
     }
     // Deplete sector resources regardless of cargo (result.mined could be 0 if cargo full)
     if (result.resource && mining.sectorYield > 0) {
@@ -289,7 +289,7 @@ export class MiningService {
       if (miningXp > 0) {
         addAcepXpForPlayer(auth.userId, 'ausbau', miningXp).catch(() => {});
       }
-      awardWissen(auth.userId, 1).catch(() => {});  // +1 per mining load
+      awardWissenAndNotify(client, auth.userId, 1);  // +1 per mining load
     }
 
     await saveMiningState(auth.userId, result.newState);

--- a/packages/server/src/rooms/services/NavigationService.ts
+++ b/packages/server/src/rooms/services/NavigationService.ts
@@ -4,7 +4,7 @@ import type { AuthPayload } from '../../auth.js';
 import type { JumpMessage, HyperJumpMessage, ShipStats } from '@void-sector/shared';
 import { isInt, rejectGuest, MAX_COORD } from './utils.js';
 import { addAcepXpForPlayer } from '../../engine/acepXpService.js';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { logger } from '../../utils/logger.js';
 
 import { generateSector } from '../../engine/worldgen.js';
@@ -150,7 +150,7 @@ export class NavigationService {
     // Quadrant first-contact detection
     await this.ctx.checkFirstContact(client, auth, sectorX, sectorY);
 
-    awardWissen(auth.userId, 1).catch(() => {});  // +1 per new sector
+    awardWissenAndNotify(client, auth.userId, 1);  // +1 per new sector
   }
 
   /**
@@ -361,7 +361,7 @@ export class NavigationService {
     // Quadrant first-contact detection
     await this.ctx.checkFirstContact(client, auth, targetX, targetY);
 
-    awardWissen(auth.userId, 1).catch(() => {});  // +1 per new sector
+    awardWissenAndNotify(client, auth.userId, 1);  // +1 per new sector
 
     // Record quadrant discovery news event on cross-quadrant jump
     if (crossQuadrant) {
@@ -375,7 +375,7 @@ export class NavigationService {
         eventData: { fromQuadrant: { qx: curQx, qy: curQy }, toQuadrant: { qx: tgtQx, qy: tgtQy } },
       }).catch(() => {});
       // ACEP: EXPLORER-XP (+50) for world-first quadrant discovery is handled in WorldService.checkFirstContact
-      awardWissen(auth.userId, 5).catch(() => {});  // +5 per quadrant change
+      awardWissenAndNotify(client, auth.userId, 5);  // +5 per quadrant change
     }
   }
 
@@ -1356,7 +1356,7 @@ export class NavigationService {
     if (!pgSectorAlreadyKnown) {
       addAcepXpForPlayer(auth.userId, 'explorer', 10).catch(() => {});
     }
-    awardWissen(auth.userId, 1).catch(() => {});  // +1 per new sector
+    awardWissenAndNotify(client, auth.userId, 1);  // +1 per new sector
 
     // Check cross-quadrant
     const { qx: curQx, qy: curQy } = sectorToQuadrant(sx, sy);
@@ -1397,7 +1397,7 @@ export class NavigationService {
     await this.ctx.checkFirstContact(client, auth, targetX, targetY);
 
     if (crossQuadrant) {
-      awardWissen(auth.userId, 5).catch(() => {});  // +5 per quadrant change
+      awardWissenAndNotify(client, auth.userId, 5);  // +5 per quadrant change
     }
 
     logger.info(

--- a/packages/server/src/rooms/services/QuestService.ts
+++ b/packages/server/src/rooms/services/QuestService.ts
@@ -17,7 +17,7 @@ import { QUEST_EXPIRY_DAYS, FACTION_UPGRADES, UNIVERSE_TICK_MS } from '@void-sec
 import { redis } from './RedisAPStore.js';
 import { generateStationNpcs, getStationFaction } from '../../engine/npcgen.js';
 import { generateStationQuests } from '../../engine/questgen.js';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { validateAcceptQuest, getReputationTier, calculateLevel } from '../../engine/commands.js';
 import {
   getPlayerReputations,
@@ -401,7 +401,7 @@ export class QuestService {
 
       // Wissen from quest completion, scaled by reward value
       const questWissen = (rewards.credits ?? 0) > 500 ? 10 : 5;
-      awardWissen(auth.userId, questWissen).catch(() => {});
+      awardWissenAndNotify(client, auth.userId, questWissen);
 
       this.ctx.send(client, 'questComplete', {
         id: row.id,
@@ -645,7 +645,7 @@ export class QuestService {
 
           // Wissen from quest completion, scaled by reward value
           const questWissen = (rewards.credits ?? 0) > 500 ? 10 : 5;
-          awardWissen(playerId, questWissen).catch(() => {});
+          awardWissenAndNotify(client, playerId, questWissen);
 
           // Deduct fetch resources from cargo
           for (const obj of objectives) {

--- a/packages/server/src/rooms/services/ScanService.ts
+++ b/packages/server/src/rooms/services/ScanService.ts
@@ -5,7 +5,7 @@ import type { CompleteScanEventMessage, SectorEnvironment } from '@void-sector/s
 
 import { calculateCurrentAP } from '../../engine/ap.js';
 import { addAcepXpForPlayer, getAcepXpSummary } from '../../engine/acepXpService.js';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { calculateTraits } from '../../engine/traitCalculator.js';
 import { getPersonalityComment } from '../../engine/personalityMessages.js';
 import { validateLocalScan, validateAreaScan } from '../../engine/commands.js';
@@ -167,7 +167,7 @@ export class ScanService {
     // ACEP: INTEL-XP + personality comment for scanning (spec: +3 per scan)
     addAcepXpForPlayer(auth.userId, 'intel', 3).catch(() => {});
     this._emitPersonalityComment(client, auth.userId, 'scan').catch(() => {});
-    awardWissen(auth.userId, 2).catch(() => {});  // +2 per scan
+    awardWissenAndNotify(client, auth.userId, 2);  // +2 per scan
 
     // Wissen: +10 for normal sectors, +25 for special sectors (daily cap)
     {
@@ -212,7 +212,7 @@ export class ScanService {
         // ACEP: EXPLORER-XP for ancient ruin scan (spec: +15)
         addAcepXpForPlayer(auth.userId, 'explorer', 15).catch(() => {});
         this._emitPersonalityComment(client, auth.userId, 'scan_ruin').catch(() => {});
-        awardWissen(auth.userId, 15).catch(() => {});  // +15 for ancient ruin artefact
+        awardWissenAndNotify(client, auth.userId, 15);  // +15 for ancient ruin artefact
       }
     }
 
@@ -485,7 +485,7 @@ export class ScanService {
       // +5-15 depending on artefact type
       const artefactType = scanEventData.rewardArtefactType as string | undefined;
       const artefactWissen = artefactType && ['ancient_data', 'alien_tech'].includes(artefactType) ? 15 : !artefactType ? 5 : 10;
-      awardWissen(auth.userId, artefactWissen).catch(() => {});
+      awardWissenAndNotify(client, auth.userId, artefactWissen);
     }
 
     // Handle blueprint find — stored in unified inventory (type='blueprint')

--- a/packages/server/src/rooms/services/ShipService.ts
+++ b/packages/server/src/rooms/services/ShipService.ts
@@ -10,7 +10,7 @@ import {
   isModuleUnlocked,
   MODULES,
 } from '@void-sector/shared';
-import { awardWissen } from '../../engine/wissenService.js';
+import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import {
   getAcepXpSummary,
   getAcepEffects,
@@ -264,7 +264,7 @@ export class ShipService {
 
     client.send('craftResult', { success: true, moduleId: data.moduleId });
     client.send('logEntry', `HERGESTELLT: ${mod.name ?? data.moduleId}`);
-    awardWissen(auth.userId, 3).catch(() => {});  // +3 per craft
+    awardWissenAndNotify(client, auth.userId, 3);  // +3 per craft
   }
 
   async handleActivateBlueprint(client: Client, data: { moduleId: string }): Promise<void> {


### PR DESCRIPTION
## Summary
- **Wissen never sent to client**: All `awardWissen()` calls were fire-and-forget with no `wissenUpdate` message. The ACEP `[+5]` path buttons require Wissen ≥ 3 but `research.wissen` stayed 0 in the UI forever. Added `awardWissenAndNotify(client, userId, amount)` helper that chains a `wissenUpdate` send after the DB write — used in ScanService, NavigationService, MiningService, CombatService, QuestService, ShipService.
- **Admin cargo PATCH accepts batch format**: Previously only accepted `{resource, amount}` (single item). Now also accepts `{items: [{itemId, quantity}, ...]}` for setting multiple resources in one call. Input validation runs before DB queries so 400s still fire correctly.

## Test plan
- [ ] Mine ore → Wissen counter in ACEP screen increments immediately
- [ ] Scan a sector → Wissen increments
- [ ] ACEP `[+5]` path buttons enable once Wissen ≥ 3
- [ ] Admin `PATCH /players/:id/cargo` with `{items: [...]}` sets multiple cargo items

Found in automated playtest #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)