### PR TITLE
feat: Admin — Add Cargo Item mit Typ/Item-Dropdown + Data Slate Creator

### DIFF
--- a/packages/server/src/admin/console.html
+++ b/packages/server/src/admin/console.html
@@ -936,6 +936,14 @@ expiresDays: 14"></textarea>
   var API_BASE = '/admin/api';
   var allPlayers = [];
   var refreshInterval = null;
+  var catalog = { resources: [], modules: [], blueprints: [] };
+
+  function loadCatalog() {
+    api('GET', '/catalog').then(function(data) {
+      catalog = data;
+    }).catch(function() { /* non-critical, use fallback */ });
+  }
+  loadCatalog();
 
   // ── Utilities ──────────────────────────────────────────────────
 
@@ -1281,28 +1289,89 @@ expiresDays: 14"></textarea>
       editCr.appendChild(crRow);
       panel.appendChild(editCr);
 
-      // Edit: Cargo item
+      // Add Cargo Item (resource / module / blueprint / data_slate)
       var editCargo = el('div', { style: 'margin-top:10px' });
-      editCargo.appendChild(el('h4', { style: 'margin:0 0 6px' }, 'Edit Cargo Item'));
-      var cargoEditRow = el('div', { style: 'display:flex;gap:8px;align-items:center;flex-wrap:wrap' });
-      var inputRes = el('input', { type: 'text', list: 'cargo-items', style: 'width:140px', placeholder: 'resource...' });
-      var inputAmt = el('input', { type: 'number', value: '0', style: 'width:80px', placeholder: 'qty' });
-      var btnCargo = el('button', null, 'Set Cargo');
-      btnCargo.addEventListener('click', function() {
-        var res = inputRes.value.trim();
-        var amt = parseInt(inputAmt.value, 10);
-        if (!res) { toast('Enter resource name', 'error'); return; }
-        if (isNaN(amt) || amt < 0) { toast('Invalid quantity', 'error'); return; }
-        api('PATCH', '/players/' + encodeURIComponent(p.id) + '/cargo', { resource: res, amount: amt }).then(function() {
-          toast('Cargo updated', 'success');
-        }).catch(function(err) { toast('Error: ' + err.message, 'error'); });
+      editCargo.appendChild(el('h4', { style: 'margin:0 0 8px' }, 'Add Cargo Item'));
+
+      var cargoRow1 = el('div', { style: 'display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px' });
+
+      var selectType = el('select', { style: 'width:130px' });
+      [['resource','Resource'], ['module','Module'], ['blueprint','Blueprint'], ['data_slate','Data Slate']].forEach(function(opt) {
+        selectType.appendChild(el('option', { value: opt[0] }, opt[1]));
       });
-      cargoEditRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Resource:'));
-      cargoEditRow.appendChild(inputRes);
-      cargoEditRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Qty:'));
-      cargoEditRow.appendChild(inputAmt);
-      cargoEditRow.appendChild(btnCargo);
-      editCargo.appendChild(cargoEditRow);
+
+      var selectItem = el('select', { style: 'width:180px' });
+      var inputQty = el('input', { type: 'number', value: '1', min: '1', style: 'width:70px' });
+
+      // Slate coords row (hidden by default)
+      var slateRow = el('div', { style: 'display:none;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px' });
+      var inputQX = el('input', { type: 'number', value: '0', style: 'width:60px', placeholder: 'QX' });
+      var inputQY = el('input', { type: 'number', value: '0', style: 'width:60px', placeholder: 'QY' });
+      var inputSX = el('input', { type: 'number', value: '0', style: 'width:60px', placeholder: 'SX' });
+      var inputSY = el('input', { type: 'number', value: '0', style: 'width:60px', placeholder: 'SY' });
+      slateRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Quadrant:'));
+      slateRow.appendChild(inputQX);
+      slateRow.appendChild(inputQY);
+      slateRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Sektor:'));
+      slateRow.appendChild(inputSX);
+      slateRow.appendChild(inputSY);
+
+      function populateItemSelect(type) {
+        var items = type === 'resource' ? catalog.resources
+                  : type === 'module'   ? catalog.modules
+                  : type === 'blueprint' ? catalog.blueprints
+                  : [];
+        while (selectItem.firstChild) selectItem.removeChild(selectItem.firstChild);
+        items.forEach(function(id) { selectItem.appendChild(el('option', { value: id }, id)); });
+        var isSlate = type === 'data_slate';
+        selectItem.style.display = isSlate ? 'none' : '';
+        inputQty.style.display   = isSlate ? 'none' : '';
+        slateRow.style.display   = isSlate ? 'flex'  : 'none';
+      }
+
+      selectType.addEventListener('change', function() { populateItemSelect(selectType.value); });
+      populateItemSelect('resource');
+
+      var btnAddItem = el('button', null, 'Add Item');
+      btnAddItem.addEventListener('click', function() {
+        var type = selectType.value;
+        if (type === 'resource') {
+          var res = selectItem.value;
+          var amt = parseInt(inputQty.value, 10);
+          if (!res) { toast('Pick a resource', 'error'); return; }
+          if (isNaN(amt) || amt < 1) { toast('Invalid quantity', 'error'); return; }
+          api('PATCH', '/players/' + encodeURIComponent(p.id) + '/cargo', { resource: res, amount: amt }).then(function() {
+            toast('Cargo updated', 'success');
+          }).catch(function(err) { toast('Error: ' + err.message, 'error'); });
+        } else if (type === 'module' || type === 'blueprint') {
+          var itemId = selectItem.value;
+          var qty = parseInt(inputQty.value, 10);
+          if (!itemId) { toast('Pick an item', 'error'); return; }
+          if (isNaN(qty) || qty < 1) { toast('Invalid quantity', 'error'); return; }
+          api('PATCH', '/players/' + encodeURIComponent(p.id) + '/inventory', { itemType: type, itemId: itemId, quantity: qty }).then(function() {
+            toast('Inventory updated', 'success');
+          }).catch(function(err) { toast('Error: ' + err.message, 'error'); });
+        } else if (type === 'data_slate') {
+          var qx = parseInt(inputQX.value, 10);
+          var qy = parseInt(inputQY.value, 10);
+          var sx = parseInt(inputSX.value, 10);
+          var sy = parseInt(inputSY.value, 10);
+          if ([qx, qy, sx, sy].some(isNaN)) { toast('Invalid coordinates', 'error'); return; }
+          api('POST', '/players/' + encodeURIComponent(p.id) + '/slates', { quadrantX: qx, quadrantY: qy, sectorX: sx, sectorY: sy }).then(function(data) {
+            toast('Slate created (' + data.absX + ',' + data.absY + ')', 'success');
+          }).catch(function(err) { toast('Error: ' + err.message, 'error'); });
+        }
+      });
+
+      cargoRow1.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Type:'));
+      cargoRow1.appendChild(selectType);
+      cargoRow1.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Item:'));
+      cargoRow1.appendChild(selectItem);
+      cargoRow1.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Qty:'));
+      cargoRow1.appendChild(inputQty);
+      cargoRow1.appendChild(btnAddItem);
+      editCargo.appendChild(cargoRow1);
+      editCargo.appendChild(slateRow);
       panel.appendChild(editCargo);
 
       container.appendChild(panel);
@@ -2782,22 +2851,5 @@ expiresDays: 14"></textarea>
 })();
 </script>
 
-<datalist id="cargo-items">
-  <option value="ore">
-  <option value="gas">
-  <option value="crystal">
-  <option value="artefact">
-  <option value="artefact_drive">
-  <option value="artefact_cargo">
-  <option value="artefact_scanner">
-  <option value="artefact_armor">
-  <option value="artefact_weapon">
-  <option value="artefact_shield">
-  <option value="artefact_defense">
-  <option value="artefact_special">
-  <option value="artefact_mining">
-  <option value="fuel_cell">
-  <option value="slates">
-</datalist>
 </body>
 </html>

--- a/packages/server/src/adminRoutes.ts
+++ b/packages/server/src/adminRoutes.ts
@@ -38,8 +38,16 @@ import {
   getConstructionSiteById,
   deleteConstructionSiteById,
 } from './db/constructionQueries.js';
-import { createStructure } from './db/queries.js';
+import {
+  createStructure,
+  upsertInventory,
+  getSector,
+  createDataSlate,
+  updateSlateOwner,
+  addSlateToCargo,
+} from './db/queries.js';
 import { constructionBus } from './constructionBus.js';
+import { MODULES, QUADRANT_SIZE } from '@void-sector/shared';
 
 export const adminRouter = Router();
 
@@ -173,6 +181,83 @@ adminRouter.patch('/players/:id/cargo', async (req: Request, res: Response) => {
     res.json({ ok: true });
   } catch (err) {
     logger.error({ err }, 'Admin set player cargo error');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Catalog (for admin UI dropdowns) ────────────────────────────────
+
+adminRouter.get('/catalog', (_req: Request, res: Response) => {
+  const resources = ['ore', 'gas', 'crystal', 'artefact', 'fuel_cell',
+    'artefact_drive', 'artefact_cargo', 'artefact_scanner', 'artefact_armor',
+    'artefact_weapon', 'artefact_shield', 'artefact_defense', 'artefact_special',
+    'artefact_mining', 'artefact_generator', 'artefact_repair'];
+  const moduleIds = Object.keys(MODULES).sort();
+  res.json({ resources, modules: moduleIds, blueprints: moduleIds });
+});
+
+// ── Inventory (modules & blueprints) ────────────────────────────────
+
+adminRouter.patch('/players/:id/inventory', async (req: Request, res: Response) => {
+  try {
+    const { itemType, itemId, quantity } = req.body;
+    if (!['module', 'blueprint'].includes(itemType)) {
+      res.status(400).json({ error: 'itemType must be module or blueprint' });
+      return;
+    }
+    if (typeof itemId !== 'string' || !itemId) {
+      res.status(400).json({ error: 'itemId must be a non-empty string' });
+      return;
+    }
+    if (typeof quantity !== 'number' || quantity < 1) {
+      res.status(400).json({ error: 'quantity must be a positive number' });
+      return;
+    }
+    const player = await getPlayerById(req.params.id as string);
+    if (!player) {
+      res.status(404).json({ error: 'Player not found' });
+      return;
+    }
+    await upsertInventory(req.params.id as string, itemType, itemId, Math.round(quantity));
+    await logAdminEvent('add_player_inventory', { playerId: req.params.id, itemType, itemId, quantity });
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, 'Admin add inventory error');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Data Slates ──────────────────────────────────────────────────────
+
+adminRouter.post('/players/:id/slates', async (req: Request, res: Response) => {
+  try {
+    const { quadrantX, quadrantY, sectorX, sectorY } = req.body;
+    for (const [name, val] of Object.entries({ quadrantX, quadrantY, sectorX, sectorY })) {
+      if (typeof val !== 'number' || !Number.isInteger(val)) {
+        res.status(400).json({ error: `${name} must be an integer` });
+        return;
+      }
+    }
+    const player = await getPlayerById(req.params.id as string);
+    if (!player) {
+      res.status(404).json({ error: 'Player not found' });
+      return;
+    }
+    // Convert quadrant + inner sector coords to absolute
+    const absX = quadrantX * QUADRANT_SIZE + sectorX;
+    const absY = quadrantY * QUADRANT_SIZE + sectorY;
+    const sector = await getSector(absX, absY);
+    if (!sector) {
+      res.status(404).json({ error: `Sector (${absX}, ${absY}) not found in DB — visit it first to generate it` });
+      return;
+    }
+    const { id: slateId } = await createDataSlate(req.params.id as string, 'scanned_sector', [sector]);
+    await updateSlateOwner(slateId, req.params.id as string);
+    await addSlateToCargo(req.params.id as string, 1);
+    await logAdminEvent('give_player_slate', { playerId: req.params.id, quadrantX, quadrantY, sectorX, sectorY, absX, absY, slateId });
+    res.json({ ok: true, slateId, absX, absY });
+  } catch (err) {
+    logger.error({ err }, 'Admin give slate error');
     res.status(500).json({ error: 'Internal server error' });
   }
 });


### PR DESCRIPTION
## Summary
- **#329**: „Edit Cargo Item" → „Add Cargo Item" mit Type-Dropdown (Resource / Module / Blueprint / Data Slate) und dynamisch gefiltertem Item-Dropdown (via neuer `/catalog` API)
- **#328**: Bei Typ „Data Slate" erscheinen Koordinaten-Inputs (Quadrant QX/QY + Sektor SX/SY) statt Item-Dropdown; Server erstellt echten `data_slate` in DB und weist ihn dem Spieler zu

## Neue API-Endpoints
| Endpoint | Funktion |
|---|---|
| `GET /admin/api/catalog` | Gibt `{ resources, modules, blueprints }` zurück für UI-Dropdowns |
| `PATCH /admin/api/players/:id/inventory` | Fügt Module/Blueprints per `upsertInventory` hinzu |
| `POST /admin/api/players/:id/slates` | Erstellt Data Slate aus `quadrantX/Y + sectorX/Y`, weist Spieler zu |

## Test plan
- [ ] Admin-Panel öffnen → Player auswählen → „Add Cargo Item" zeigt Type-Dropdown
- [ ] Type „Resource" → Item-Dropdown zeigt ore/gas/crystal/... → Add Item → cargo updated ✓
- [ ] Type „Module" → Item-Dropdown zeigt alle Module-IDs → Add Item → inventory updated ✓
- [ ] Type „Blueprint" → Item-Dropdown zeigt alle Module-IDs → Add Item → inventory updated ✓
- [ ] Type „Data Slate" → Item/Qty verschwindet, Koordinaten-Inputs erscheinen → Create → Slate in DB ✓
- [ ] Ungültige Koordinaten (kein Sektor in DB) → Fehlermeldung mit Hinweis auf visit-first ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)