### PR TITLE
fix: module currentHp on install + adminSetCargoItem inventory table

### DIFF
--- a/packages/server/src/__tests__/moduleInventory.test.ts
+++ b/packages/server/src/__tests__/moduleInventory.test.ts
@@ -49,6 +49,7 @@ vi.mock('@void-sector/shared', () => ({
   isModuleUnlocked: vi.fn().mockReturnValue(true),
   RESEARCH_TICK_MS: 60000,
   getActiveDrawbacks: vi.fn().mockReturnValue([]),
+  MODULE_HP_BY_TIER: { 1: 20, 2: 30, 3: 40, 4: 50, 5: 60 },
 }));
 
 // ── Mock techTreeQueries ─────────────────────────────────────────────────────

--- a/packages/server/src/db/adminQueries.ts
+++ b/packages/server/src/db/adminQueries.ts
@@ -143,12 +143,15 @@ export async function adminSetCargoItem(
   amount: number,
 ): Promise<void> {
   if (amount <= 0) {
-    await query(`DELETE FROM cargo WHERE player_id = $1 AND resource = $2`, [id, resource]);
+    await query(
+      `DELETE FROM inventory WHERE player_id = $1 AND item_type = 'resource' AND item_id = $2`,
+      [id, resource],
+    );
   } else {
     await query(
-      `INSERT INTO cargo (player_id, resource, quantity)
-       VALUES ($1, $2, $3)
-       ON CONFLICT (player_id, resource)
+      `INSERT INTO inventory (player_id, item_type, item_id, quantity)
+       VALUES ($1, 'resource', $2, $3)
+       ON CONFLICT (player_id, item_type, item_id)
        DO UPDATE SET quantity = $3`,
       [id, resource, amount],
     );

--- a/packages/server/src/rooms/services/ShipService.ts
+++ b/packages/server/src/rooms/services/ShipService.ts
@@ -9,6 +9,7 @@ import {
   getActiveDrawbacks,
   isModuleUnlocked,
   MODULES,
+  MODULE_HP_BY_TIER,
 } from '@void-sector/shared';
 import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import {
@@ -86,10 +87,12 @@ export class ShipService {
       return;
     }
     await removeFromInventory(auth.userId, 'module', data.moduleId, 1);
-    // Install — source defaults to 'standard' (inventory-tracked source TBD)
+    // Install — initialize currentHp to maxHp so the MODULE tab shows a full HP bar
+    const modDef = MODULES[data.moduleId];
+    const maxHp = modDef?.maxHp ?? MODULE_HP_BY_TIER[modDef?.tier ?? 1] ?? 20;
     const newModules: ShipModule[] = [
       ...ship.modules,
-      { moduleId: data.moduleId, slotIndex: data.slotIndex, source: 'standard' as const },
+      { moduleId: data.moduleId, slotIndex: data.slotIndex, source: 'standard' as const, currentHp: maxHp },
     ];
     await updateShipModules(ship.id, newModules);
     // Recalculate stats and collect active drawbacks


### PR DESCRIPTION
## Summary
- **Module HP bar empty after install**: `handleInstallModule` now sets `currentHp = maxHp` based on `MODULE_HP_BY_TIER` so the MODULE tab shows a full HP bar immediately
- **Admin cargo writes to wrong table**: `adminSetCargoItem` was writing to the legacy `cargo` table; game reads from `inventory` — fixed to upsert into `inventory (item_type='resource')`
- Updated `moduleInventory.test.ts` mock to include `MODULE_HP_BY_TIER`

## Test plan
- [ ] Install a module → MODULE tab shows full HP bar
- [ ] Admin panel: set cargo → resources appear in CARGO tab in-game
- [ ] Server tests: `moduleInventory.test.ts` all 5 pass

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)