### PR TITLE
fix: unify human faction ID 'human' → 'humans'

### DIFF
--- a/packages/server/src/db/migrations/061_fix_human_faction_id.sql
+++ b/packages/server/src/db/migrations/061_fix_human_faction_id.sql
@@ -1,0 +1,34 @@
+-- Fix faction ID: rename 'human' -> 'humans' to match COSMIC_FACTION_IDS in shared constants
+
+-- 1. Update faction_config primary key (rename the row)
+INSERT INTO faction_config (faction_id, home_qx, home_qy, expansion_rate, aggression, expansion_style, active)
+SELECT 'humans', home_qx, home_qy, expansion_rate, aggression, expansion_style, active
+FROM faction_config
+WHERE faction_id = 'human'
+ON CONFLICT (faction_id) DO NOTHING;
+
+DELETE FROM faction_config WHERE faction_id = 'human';
+
+-- 2. Update quadrant_control rows controlled by 'human'
+UPDATE quadrant_control
+SET
+  controlling_faction = 'humans',
+  faction_shares = (
+    CASE
+      WHEN faction_shares ? 'human'
+      THEN (faction_shares - 'human') || jsonb_build_object('humans', faction_shares->'human')
+      ELSE faction_shares
+    END
+  )
+WHERE controlling_faction = 'human';
+
+-- 3. Fix any remaining faction_shares JSONB that contain 'human' key (partial shares)
+UPDATE quadrant_control
+SET faction_shares = (faction_shares - 'human') || jsonb_build_object('humans', faction_shares->'human')
+WHERE faction_shares ? 'human';
+
+-- 4. Update the column default
+ALTER TABLE quadrant_control ALTER COLUMN controlling_faction SET DEFAULT 'humans';
+
+-- 5. Update expansion_log if it exists
+UPDATE expansion_log SET faction_id = 'humans' WHERE faction_id = 'human';

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -3264,7 +3264,7 @@ export async function ensureZentrumQuadrant(): Promise<void> {
   // Ensure quadrant_control entry exists for (0,0) as human home quadrant
   await query(
     `INSERT INTO quadrant_control (qx, qy, controlling_faction, faction_shares, attack_value, defense_value, friction_score, station_tier)
-     VALUES (0, 0, 'human', '{"human": 100}', 0, 100, 0, 1)
+     VALUES (0, 0, 'humans', '{"humans": 100}', 0, 100, 0, 1)
      ON CONFLICT (qx, qy) DO NOTHING`,
   );
 }
@@ -3273,7 +3273,7 @@ export async function ensureAlienHomeQuadrants(): Promise<number> {
   const factions = await getAllFactionConfigs();
   let seeded = 0;
   for (const f of factions) {
-    if (f.faction_id === 'human') continue;
+    if (f.faction_id === 'humans') continue;
     // Ensure quadrant row exists
     await query(
       `INSERT INTO quadrants (qx, qy, seed, name, discovered_by, discovered_at, config)

--- a/packages/server/src/engine/civStationService.ts
+++ b/packages/server/src/engine/civStationService.ts
@@ -26,7 +26,7 @@ export async function ensureCivStations(): Promise<void> {
   let seeded = 0;
 
   for (const q of controls) {
-    if (!q.controlling_faction || q.controlling_faction === 'human') continue;
+    if (!q.controlling_faction || q.controlling_faction === 'humans') continue;
 
     const center = getQuadrantCenter(q.qx, q.qy);
     await civQueries.upsertStation(center.x, center.y, q.controlling_faction);

--- a/packages/server/src/engine/strategicTickService.ts
+++ b/packages/server/src/engine/strategicTickService.ts
@@ -47,11 +47,11 @@ export class StrategicTickService {
     // 1. Update friction + handle warfare at all human<→alien borders
     const borderPairs = findAllBorderPairs(allControls);
     for (const { a, b } of borderPairs) {
-      if (a.controlling_faction !== 'human' && b.controlling_faction !== 'human') continue;
+      if (a.controlling_faction !== 'humans' && b.controlling_faction !== 'humans') continue;
       const alienFaction =
-        a.controlling_faction === 'human' ? b.controlling_faction : a.controlling_faction;
-      const humanQ = a.controlling_faction === 'human' ? a : b;
-      const alienQ = a.controlling_faction === 'human' ? b : a;
+        a.controlling_faction === 'humans' ? b.controlling_faction : a.controlling_faction;
+      const humanQ = a.controlling_faction === 'humans' ? a : b;
+      const alienQ = a.controlling_faction === 'humans' ? b : a;
 
       const rep = repStore.get(alienFaction) ?? 0;
       const repTier = repValueToTier(rep);
@@ -137,7 +137,7 @@ export class StrategicTickService {
         station_tier: humanQ.station_tier,
       });
       await logExpansionEvent(alienFaction, humanQ.qx, humanQ.qy, 'conquered');
-      await logExpansionEvent('human', humanQ.qx, humanQ.qy, 'lost');
+      await logExpansionEvent('humans', humanQ.qx, humanQ.qy, 'lost');
       const msg = `${alienFaction.toUpperCase()} CONQUEST — Quadrant [${humanQ.qx}/${humanQ.qy}] lost`;
       logger.warn({ alienFaction, qx: humanQ.qx, qy: humanQ.qy }, msg);
       await this.pushWarTickerEvent(msg);
@@ -181,7 +181,7 @@ export class StrategicTickService {
   private async processAlienExpansion(
     allControls: QuadrantControlRow[],
   ): Promise<void> {
-    const factions = this.factionConfig.getActiveFactions().filter((f) => f.faction_id !== 'human');
+    const factions = this.factionConfig.getActiveFactions().filter((f) => f.faction_id !== 'humans');
 
     for (const faction of factions) {
       const target = getExpansionTarget(

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -1427,7 +1427,7 @@ export class SectorRoom extends Room<SectorRoomState> {
             const isAlien = alienFactionIds.has(r.controlling_faction);
             const controlling_faction =
               isAlien && !contactedAlienIds.has(r.controlling_faction)
-                ? 'human'
+                ? 'humans'
                 : r.controlling_faction;
             return {
               qx: r.qx,

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -1657,13 +1657,13 @@ export class WorldService {
         // ACEP: EXPLORER-XP bonus for first quadrant discovery (spec: +50)
         addAcepXpForPlayer(auth.userId, 'explorer', 50).catch(() => {});
         // Log world-first quadrant discovery
-        logExpansionEvent('human', qx, qy, 'discovered').catch(() => {});
+        logExpansionEvent('humans', qx, qy, 'discovered').catch(() => {});
       } else {
         // Quadrant exists but player may not know it yet
         const alreadyKnown = await playerKnowsQuadrant(auth.userId, qx, qy);
         await addPlayerKnownQuadrant(auth.userId, qx, qy);
         if (!alreadyKnown) {
-          logExpansionEvent('human', qx, qy, 'discovered').catch(() => {});
+          logExpansionEvent('humans', qx, qy, 'discovered').catch(() => {});
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

Two separate string literals were used for the human faction ID throughout the codebase:

- **`'humans'`** (plural) — used in `COSMIC_FACTION_IDS` (shared), `universeTickEngine.ts`
- **`'human'`** (singular) — used in `strategicTickService.ts`, `civStationService.ts`, `queries.ts`, `SectorRoom.ts`, `WorldService.ts`, migration 043 seed data

This caused human territory to be **invisible to the warfare/expansion engine**: border detection looked for `'humans'` but DB rows were stored as `'human'`, so no human↔alien borders were ever found.

## Fix

- Unified all server-side faction ID references to `'humans'` (matching shared constants)
- Added **migration 061** to update existing DB rows:
  - `faction_config`: rename `'human'` row to `'humans'`
  - `quadrant_control`: update `controlling_faction` + `faction_shares` JSONB keys
  - `expansion_log`: update `faction_id` column
  - Changed column default from `'human'` to `'humans'`

## Files changed

| File | Change |
|------|--------|
| `strategicTickService.ts` | 5× `'human'` → `'humans'` (border detection + expansion filter) |
| `civStationService.ts` | 1× skip condition |
| `queries.ts` | seed INSERT + skip condition |
| `SectorRoom.ts` | display fallback for uncontacted alien quadrants |
| `WorldService.ts` | 2× `logExpansionEvent` calls |
| `migrations/061_fix_human_faction_id.sql` | NEW — data migration |

🤖 Generated with [Claude Code](https://claude.com/claude-code)