### PR TITLE
fix: STORY tab crash + HUMANITY REP stuck on LOADING

### DIFF
--- a/packages/client/src/components/FactionDetailPanel.tsx
+++ b/packages/client/src/components/FactionDetailPanel.tsx
@@ -101,9 +101,9 @@ function FactionRecruitPanel() {
     return () => clearInterval(t);
   }, [recruitingFactions.length]);
 
-  const repEntries = Object.values(humanityReps);
-  const totalRep = repEntries.reduce((sum, e) => sum + e.repValue, 0);
-  const repTier = repEntries.length > 0 ? getRepTier(totalRep) : null;
+  const repEntries = humanityReps ? Object.values(humanityReps) : null;
+  const totalRep = repEntries ? repEntries.reduce((sum, e) => sum + e.repValue, 0) : 0;
+  const repTier = repEntries ? getRepTier(totalRep) : null;
   const currentCard = recruitingFactions[cardIdx] ?? null;
 
   return (

--- a/packages/client/src/components/QuestsScreen.tsx
+++ b/packages/client/src/components/QuestsScreen.tsx
@@ -310,6 +310,7 @@ function JournalTab() {
 }
 
 function StoryTab() {
+  const { t } = useTranslation('ui');
   const progress = useStore((s) => s.storyProgress);
 
   useEffect(() => {
@@ -416,7 +417,7 @@ function AlienRepTab() {
         GALACTIC HUMANITY REP
       </div>
       {Object.entries(FACTION_LABELS).map(([id, label]) => {
-        const entry = humanityReps[id];
+        const entry = humanityReps?.[id];
         if (!entry)
           return (
             <div

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -353,7 +353,7 @@ export interface GameSlice {
   credits: number;
   alienCredits: number;
   alienReputations: Record<string, number>;
-  humanityReps: Record<string, { repValue: number; tier: 'FEINDSELIG' | 'NEUTRAL' | 'FREUNDLICH' }>;
+  humanityReps: Record<string, { repValue: number; tier: 'FEINDSELIG' | 'NEUTRAL' | 'FREUNDLICH' }> | null;
 
   // Storage
   storage: StorageInventory;
@@ -748,7 +748,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
   credits: 0,
   alienCredits: 0,
   alienReputations: {},
-  humanityReps: {},
+  humanityReps: null,
   storage: { ore: 0, gas: 0, crystal: 0, artefact: 0 },
   tradeOrders: [],
   myOrders: [],


### PR DESCRIPTION
## Summary
- **STORY tab crashes**: `StoryTab` component called `t('status.loading')` without importing/calling `useTranslation('ui')` — caused `ReferenceError: t is not defined`, crashing the QUEST monitor with MONITOR OFFLINE
- **HUMANITY REP: LOADING... stuck**: `humanityReps` initial state was `{}` (empty object), indistinguishable from a server response with no data — the panel showed LOADING... forever even after data arrived. Fixed by initializing to `null` and checking `humanityReps !== null` for the loaded state

## Test plan
- [ ] Open QUESTS → STORY tab: renders without crashing (no MONITOR OFFLINE)
- [ ] Open FACTION panel: HUMANITY REP shows "NEUTRAL +0" for new players (not LOADING...)
- [ ] Client tests: no new failures vs master baseline

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)