### PR TITLE
fix: send existing construction site to client on room join

### DIFF
--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -1188,6 +1188,9 @@ export class SectorRoom extends Room<SectorRoomState> {
       // Send sector data to client
       client.send('sectorData', sectorData);
 
+      // Send existing construction site at this sector (if any)
+      await this.world.sendConstructionSiteOnJoin(client, sectorX, sectorY);
+
       // Send quadrant info (name + coords)
       const quadrantData = await getQuadrant(this.quadrantX, this.quadrantY);
       client.send('quadrantInfo', {

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -1670,4 +1670,12 @@ export class WorldService {
       logger.error({ err }, 'checkFirstContact error');
     }
   }
+
+  /** Send existing construction site at the current sector to a joining client. */
+  async sendConstructionSiteOnJoin(client: Client, sectorX: number, sectorY: number): Promise<void> {
+    const site = await getConstructionSite(sectorX, sectorY);
+    if (site) {
+      client.send('constructionSiteCreated', { site: toConstructionSiteState(site) });
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Construction sites (Baustellen) were invisible after page reload or room rejoin. The server only pushed `constructionSiteCreated` when a **new** site was built — existing sites were never sent to joining clients.

**Fix**: Add `WorldService.sendConstructionSiteOnJoin()` that queries the DB for a construction site at the current sector and sends `constructionSiteCreated` if one exists. Called from `SectorRoom.onJoin` immediately after `sectorData` is sent.

## Test plan
- [ ] Build a construction site, reload page → site reappears in Detail panel
- [ ] Navigate away and return to the same sector → site still visible
- [ ] Server tests: 126 pass (5 pre-existing failures unchanged)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)