### PR TITLE
fix: resolve TradeScreen ReferenceErrors and show quest errors inline

### DIFF
--- a/packages/client/src/__tests__/FactionDetailPanel.test.tsx
+++ b/packages/client/src/__tests__/FactionDetailPanel.test.tsx
@@ -117,7 +117,8 @@ describe('FactionDetailPanel — State A (member)', () => {
 describe('FactionDetailPanel — State B (non-member)', () => {
   beforeEach(() => { vi.clearAllMocks(); noFactionState(); });
 
-  it('shows LOADING when humanityReps empty', () => {
+  it('shows LOADING when humanityReps is null', () => {
+    noFactionState({ humanityReps: null });
     render(<FactionDetailPanel />);
     expect(screen.getByText(/HUMANITY REP: LOADING/)).toBeDefined();
   });

--- a/packages/client/src/components/QuestsScreen.tsx
+++ b/packages/client/src/components/QuestsScreen.tsx
@@ -8,6 +8,7 @@ import { findNearestStation } from '../utils/sectorUtils';
 import { useTranslation } from 'react-i18next';
 import { btn, btnDisabled } from '../ui-helpers';
 import { useConfirm } from '../hooks/useConfirm';
+import { InlineError } from './InlineError';
 
 const MAX_TRACKED = 5;
 
@@ -923,6 +924,7 @@ export function QuestsScreen() {
       {/* VERFÜGBAR tab: station + community + events */}
       {tab === 'verfuegbar' && (
         <div>
+          <InlineError codes={['QUEST_ERROR']} />
           {/* Station quests */}
           <div style={{ color: '#FFB000', marginBottom: '4px' }}>--- STATION ---</div>
           {!isAtStation && (() => {

--- a/packages/client/src/components/TradeScreen.tsx
+++ b/packages/client/src/components/TradeScreen.tsx
@@ -6,7 +6,12 @@ import {
   TRADE_ROUTE_MIN_CYCLE,
   TRADE_ROUTE_MAX_CYCLE,
   getPhysicalCargoTotal,
+  NPC_PRICES,
+  NPC_BUY_SPREAD,
+  NPC_SELL_SPREAD,
 } from '@void-sector/shared';
+
+const NPC_COLUMN_MAX_HEIGHT = '220px';
 import type { ResourceType, DataSlate, ConfigureRouteMessage } from '@void-sector/shared';
 import { useTranslation } from 'react-i18next';
 import { btn } from '../ui-helpers';
@@ -38,6 +43,7 @@ export function TradeScreen() {
   const discoveries = useStore((s) => s.discoveries);
   const homeBase = useStore((s) => s.homeBase);
   const ship = useStore((s) => s.ship);
+  const cargo = useStore((s) => s.cargo);
   const npcStationData = useStore((s) => s.npcStationData);
   const kontorOrders = useStore((s) => s.kontorOrders);
   const navReturnProgram = useStore((s) => s.navReturnProgram);

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -930,6 +930,7 @@ class GameNetwork {
         store.addLogEntry(`Quest angenommen: ${data.quest.title}`);
       } else {
         store.addLogEntry(`Quest-Fehler: ${data.error}`);
+        store.setActionError({ code: 'QUEST_ERROR', message: data.error });
       }
     });
 


### PR DESCRIPTION
## Summary
- Fix 3 `ReferenceError` crashes in TradeScreen: `cargo`, `NPC_PRICES`/`NPC_BUY_SPREAD`/`NPC_SELL_SPREAD` (missing import), and `NPC_COLUMN_MAX_HEIGHT` (undeclared constant)
- Show quest acceptance errors inline via `InlineError` component instead of LOG-only
- Update `FactionDetailPanel` test to use `humanityReps: null` for LOADING state check

## Test plan
- [ ] Open TRADE at a station — no crash on load
- [ ] Click NPC HANDEL — prices display correctly, no crash
- [ ] Try accepting a quest with full cargo — error shown inline in VERFÜGBAR tab
- [ ] All client tests pass (550/550)

Fixes found in playtest #325 (story 74c01039)

🤖 Generated with [Claude Code](https://claude.com/claude-code)