### PR TITLE
feat: admin can instantly complete construction sites in-game

### DIFF
--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -148,6 +148,7 @@ function ConstructionSitePanel({ site }: { site: ConstructionSiteState }) {
 
   const pct = site.progress;
   const canDeliver = amounts.ore + amounts.gas + amounts.crystal > 0;
+  const adminToken = localStorage.getItem('vs_admin_token');
 
   type ResKey = 'ore' | 'gas' | 'crystal';
   const rows: [string, ResKey, number][] = [
@@ -165,6 +166,15 @@ function ConstructionSitePanel({ site }: { site: ConstructionSiteState }) {
   function deliver() {
     network.sendDepositConstruction(site.id, amounts.ore, amounts.gas, amounts.crystal);
     setAmounts({ ore: 0, gas: 0, crystal: 0 });
+  }
+
+  async function adminComplete() {
+    if (!adminToken) return;
+    const base = `${window.location.protocol}//${window.location.host}`;
+    await fetch(`${base}/admin/api/construction-sites/${encodeURIComponent(site.id)}/complete`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
   }
 
   return (
@@ -241,6 +251,15 @@ function ConstructionSitePanel({ site }: { site: ConstructionSiteState }) {
             [LIEFERN]
           </button>
         </div>
+      )}
+      {adminToken && (
+        <button
+          className="vs-btn"
+          style={{ fontSize: '0.65rem', marginTop: 8, width: '100%', borderColor: '#ff4444', color: '#ff4444' }}
+          onClick={adminComplete}
+        >
+          [ADMIN: SOFORT VOLLENDEN]
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- `ConstructionSitePanel` in `DetailPanel.tsx` now shows a **[ADMIN: SOFORT VOLLENDEN]** button when `localStorage.vs_admin_token` is set
- Button calls `POST /admin/api/construction-sites/:id/complete` with Bearer token
- Only visible to players who have set the admin token — no UI change for regular players

## Usage
```js
localStorage.setItem('vs_admin_token', 'vs-admin-2026')
```
Then any construction site in the DetailPanel shows the red admin button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)