### PR TITLE
fix: community quest progress 0/0 and QUAD-MAP shows 0 known quadrants

### DIFF
--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -69,7 +69,7 @@ import {
   getInventory,
   getMiningStoryIndex,
 } from '../db/queries.js';
-import { getQuadrant } from '../db/quadrantQueries.js';
+import { getQuadrant, addPlayerKnownQuadrant } from '../db/quadrantQueries.js';
 import { query } from '../db/client.js';
 import {
   RECONNECTION_TIMEOUT_S,
@@ -889,7 +889,7 @@ export class SectorRoom extends Room<SectorRoomState> {
     });
 
     this.onMessage('getActiveCommunityQuest', async (client) => {
-      const quest = await this.communityQuests.getActive().catch(() => null);
+      const quest = await this.communityQuests.getActivePayload().catch(() => null);
       client.send('activeCommunityQuest', { quest });
     });
 
@@ -898,7 +898,7 @@ export class SectorRoom extends Room<SectorRoomState> {
       if (!auth?.userId) return;
       const amount = Math.max(1, Math.min(data.amount ?? 1, 100)); // cap at 100 per contribution
       await this.communityQuests.contribute(auth.userId, amount).catch(() => {});
-      const quest = await this.communityQuests.getActive().catch(() => null);
+      const quest = await this.communityQuests.getActivePayload().catch(() => null);
       client.send('activeCommunityQuest', { quest });
     });
 
@@ -1201,6 +1201,8 @@ export class SectorRoom extends Room<SectorRoomState> {
 
       // Record quadrant visit for Fog-of-War
       await recordQuadrantVisit(auth.userId, this.quadrantX, this.quadrantY);
+      // Ensure starting quadrant is in player's known quadrant list
+      await addPlayerKnownQuadrant(auth.userId, this.quadrantX, this.quadrantY);
 
       // Save position
       await savePlayerPosition(auth.userId, sectorX, sectorY);

--- a/packages/server/src/rooms/services/CommunityQuestService.ts
+++ b/packages/server/src/rooms/services/CommunityQuestService.ts
@@ -70,6 +70,25 @@ export class CommunityQuestService {
     return getActiveCommunityAlienQuest();
   }
 
+  async getActivePayload(): Promise<{
+    id: number; title: string; description: string | null;
+    targetCount: number; currentCount: number;
+    rewardType: string | null; expiresAt: number | null; status: string;
+  } | null> {
+    const row = await getActiveCommunityAlienQuest();
+    if (!row) return null;
+    return {
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      targetCount: row.target_count,
+      currentCount: row.current_count,
+      rewardType: row.reward_type,
+      expiresAt: row.expires_at,
+      status: row.status,
+    };
+  }
+
   async contribute(playerId: string, amount: number, questType?: string): Promise<void> {
     const quest = await getActiveCommunityAlienQuest();
     if (!quest) return;

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -1652,6 +1652,8 @@ export class WorldService {
           message: `[${quadrant.name}] charted by ${auth.username}`,
           type: 'quadrant_discovery',
         });
+        // Add to player's known quadrants
+        await addPlayerKnownQuadrant(auth.userId, qx, qy);
         // ACEP: INTEL-XP for first quadrant discovery (spec: +20)
         addAcepXpForPlayer(auth.userId, 'intel', 20).catch(() => {});
         // ACEP: EXPLORER-XP bonus for first quadrant discovery (spec: +50)


### PR DESCRIPTION
## Summary
- Community quest \"Das Große Kartenprojekt\" always showed `FORTSCHRITT: 0 / 0` — the server was sending raw DB rows with snake_case fields (`target_count`, `current_count`) but the client expected camelCase (`targetCount`, `currentCount`)
- QUAD-MAP always showed `QUADRANTS: 0 KNOWN` — the player's starting quadrant was never added to `player_known_quadrants` on join, and first-contact quadrant discovery also forgot to add it

## Changes
- `CommunityQuestService`: new `getActivePayload()` method maps DB row to camelCase payload
- `SectorRoom`: use `getActivePayload()` for `activeCommunityQuest` messages
- `WorldService.checkFirstContact`: call `addPlayerKnownQuadrant` after first discovery
- `SectorRoom.onJoin`: call `addPlayerKnownQuadrant` for starting quadrant on every login

## Test plan
- [ ] Open QUESTS → VERFÜGBAR — community quest shows correct progress e.g. `1234 / 100000`
- [ ] Open QUAD-MAP after login — origin quadrant (0,0) shows as KNOWN
- [ ] Cross into new quadrant — appears in QUAD-MAP known list
- [ ] AREA SCAN increments community quest progress counter

Fixes found in playtest #326 (story 381c3f43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)