### PR TITLE
fix: increase BASE_SCANNER_MEMORY from 2 to 10

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -266,7 +266,7 @@ export const SLATE_AREA_RADIUS: Record<number, number> = {
   3: 4,
 };
 
-export const BASE_SCANNER_MEMORY = 2;
+export const BASE_SCANNER_MEMORY = 10;
 
 export function getPhysicalCargoTotal(cargo: { ore: number; gas: number; crystal: number; artefact: number }): number {
   return cargo.ore + cargo.gas + cargo.crystal + cargo.artefact;


### PR DESCRIPTION
## Summary

- Raises the default scanner memory from 2 to 10 Data Slates
- No migration needed — value is calculated at runtime from the constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)