### PR TITLE
fix: #334 admin quadrant position, #335 fuel 100=1cr, #336 wissen display

### DIFF
--- a/packages/client/src/components/AcepTab.tsx
+++ b/packages/client/src/components/AcepTab.tsx
@@ -51,7 +51,9 @@ export function AcepTab() {
   const { t } = useTranslation('ui');
   const ship = useStore((s) => s.ship);
   const credits = useStore((s) => s.credits ?? 0);
-  const wissen = useStore((s) => s.research.wissen ?? 0);
+  const research = useStore((s) => s.research);
+  const wissen = research.wissen ?? 0;
+  const wissenSpent = research.wissenSpent ?? 0;
   const [renamingShipId, setRenamingShipId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
@@ -128,6 +130,9 @@ export function AcepTab() {
         <div style={{ color: '#555', fontSize: '0.85rem' }}>
           {t('acep.total')}: {xp.total ?? 0}/100
         </div>
+      </div>
+      <div style={{ color: '#bb44ff', fontSize: '0.75rem', marginBottom: 8, letterSpacing: '0.06em' }}>
+        WISSEN: {wissen} / [ {wissenSpent} ]
       </div>
       {PATHS.map(({ key, labelKey, color }) => {
         const pathXp = xp[key] ?? 0;

--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -73,7 +73,7 @@ function RefuelPanel({
   isFreeRefuel: boolean;
 }) {
   const { t } = useTranslation('ui');
-  const [amount, setAmount] = useState(Math.ceil(fuel.max - fuel.current));
+  const [amount, setAmount] = useState(Math.max(100, Math.floor((fuel.max - fuel.current) / 100) * 100));
   const reputations = useStore((s) => s.reputations);
   const currentSector = useStore((s) => s.currentSector);
   const npcStationData = useStore((s) => s.npcStationData);
@@ -106,8 +106,9 @@ function RefuelPanel({
       </div>
       <input
         type="range"
-        min={1}
-        max={tankSpace}
+        min={100}
+        max={Math.max(100, Math.floor(tankSpace / 100) * 100)}
+        step={100}
         value={amount}
         onChange={(e) => setAmount(Number(e.target.value))}
         style={{ width: '100%', accentColor: 'var(--color-primary)' }}

--- a/packages/client/src/components/TechTreeCanvas.tsx
+++ b/packages/client/src/components/TechTreeCanvas.tsx
@@ -949,6 +949,7 @@ export function TechTreeCanvas() {
           </span>
           <span style={{ fontSize: '0.65rem', color: '#888' }}>
             WISSEN: <span style={{ color: '#bb44ff' }}>{wissen.toLocaleString()}</span>
+            {' / [ '}<span style={{ color: '#7744aa' }}>{(research.wissenSpent ?? 0).toLocaleString()}</span>{' ]'}
             {' /// '}
             ERFORSCHT: {totalResearched}
             {' /// '}

--- a/packages/client/src/components/TechTreePanel.tsx
+++ b/packages/client/src/components/TechTreePanel.tsx
@@ -89,7 +89,7 @@ export function TechTreePanel() {
       >
         <span>{t('tech.techTree')}</span>
         <span style={{ color: '#FFB000', fontSize: '0.6rem', letterSpacing: '0.08em' }}>
-          &#x25C8; {t('tech.wissen', { n: wissen })}
+          &#x25C8; WISSEN: {wissen} / [ {research.wissenSpent ?? 0} ]
         </span>
       </div>
 

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -629,6 +629,7 @@ class GameNetwork {
         unlockedModules: data.unlockedModules ?? [],
         blueprints: data.blueprints ?? [],
         wissen: data.wissen ?? 0,
+        wissenSpent: data.wissenSpent ?? 0,
       });
       if (data.typedArtefacts) {
         useStore.getState().setTypedArtefacts(data.typedArtefacts);

--- a/packages/server/src/admin/console.html
+++ b/packages/server/src/admin/console.html
@@ -1339,26 +1339,42 @@ expiresDays: 14"></textarea>
       panel.appendChild(shipsSection);
 
       // Edit: Position
+      var QSIZE = 500;
+      var curQX = Math.floor((p.positionX + Math.floor(QSIZE/2)) / QSIZE);
+      var curQY = Math.floor((p.positionY + Math.floor(QSIZE/2)) / QSIZE);
+      var curSX = p.positionX - curQX * QSIZE;
+      var curSY = p.positionY - curQY * QSIZE;
+
       var editPos = el('div', { style: 'margin-top:14px;border-top:1px solid #333;padding-top:10px' });
       editPos.appendChild(el('h4', { style: 'margin:0 0 6px' }, 'Edit Position'));
-      var posRow = el('div', { style: 'display:flex;gap:8px;align-items:center;flex-wrap:wrap' });
-      var inputPX = el('input', { type: 'number', value: String(p.positionX), style: 'width:80px', placeholder: 'X' });
-      var inputPY = el('input', { type: 'number', value: String(p.positionY), style: 'width:80px', placeholder: 'Y' });
-      var btnPos = el('button', null, 'Set Position');
-      btnPos.addEventListener('click', function() {
-        var x = parseInt(inputPX.value, 10);
-        var y = parseInt(inputPY.value, 10);
-        if (isNaN(x) || isNaN(y)) { toast('Invalid coordinates', 'error'); return; }
-        api('PATCH', '/players/' + encodeURIComponent(p.id) + '/position', { x: x, y: y }).then(function() {
-          toast('Position updated', 'success');
+
+      // Quadrant + inner sector inputs
+      var quadRow = el('div', { style: 'display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:6px' });
+      var inputQX = el('input', { type: 'number', value: String(curQX), style: 'width:60px', placeholder: 'Q.X' });
+      var inputQY = el('input', { type: 'number', value: String(curQY), style: 'width:60px', placeholder: 'Q.Y' });
+      var inputSX = el('input', { type: 'number', value: String(curSX), style: 'width:60px', placeholder: 'S.X' });
+      var inputSY = el('input', { type: 'number', value: String(curSY), style: 'width:60px', placeholder: 'S.Y' });
+      var btnPosQ = el('button', null, 'Set');
+      btnPosQ.addEventListener('click', function() {
+        var qx = parseInt(inputQX.value, 10);
+        var qy = parseInt(inputQY.value, 10);
+        var sx = parseInt(inputSX.value, 10);
+        var sy = parseInt(inputSY.value, 10);
+        if ([qx,qy,sx,sy].some(isNaN)) { toast('Invalid coordinates', 'error'); return; }
+        var globalX = qx * QSIZE + sx;
+        var globalY = qy * QSIZE + sy;
+        api('PATCH', '/players/' + encodeURIComponent(p.id) + '/position', { x: globalX, y: globalY }).then(function() {
+          toast('Position → Q(' + qx + ',' + qy + ') S(' + sx + ',' + sy + ') = (' + globalX + ',' + globalY + ')', 'success');
         }).catch(function(err) { toast('Error: ' + err.message, 'error'); });
       });
-      posRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'X:'));
-      posRow.appendChild(inputPX);
-      posRow.appendChild(el('span', { style: 'color:#aaa;font-size:12px' }, 'Y:'));
-      posRow.appendChild(inputPY);
-      posRow.appendChild(btnPos);
-      editPos.appendChild(posRow);
+      quadRow.appendChild(el('span', { style: 'color:#aaa;font-size:11px' }, 'Quad:'));
+      quadRow.appendChild(inputQX);
+      quadRow.appendChild(inputQY);
+      quadRow.appendChild(el('span', { style: 'color:#aaa;font-size:11px' }, 'Sektor:'));
+      quadRow.appendChild(inputSX);
+      quadRow.appendChild(inputSY);
+      quadRow.appendChild(btnPosQ);
+      editPos.appendChild(quadRow);
       panel.appendChild(editPos);
 
       // Edit: Credits

--- a/packages/server/src/db/migrations/064_wissen_spent.sql
+++ b/packages/server/src/db/migrations/064_wissen_spent.sql
@@ -1,0 +1,2 @@
+-- Migration 064: Track spent Wissen for display purposes
+ALTER TABLE player_research ADD COLUMN IF NOT EXISTS wissen_spent INTEGER NOT NULL DEFAULT 0;

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -2151,12 +2151,20 @@ export async function addWissen(userId: string, amount: number): Promise<void> {
 export async function deductWissen(userId: string, amount: number): Promise<boolean> {
   const { rows } = await query<{ wissen: number }>(
     `UPDATE player_research
-     SET wissen = wissen - $2
+     SET wissen = wissen - $2, wissen_spent = wissen_spent + $2
      WHERE user_id = $1 AND wissen >= $2
      RETURNING wissen`,
     [userId, amount],
   );
   return rows.length > 0;
+}
+
+export async function getWissenSpent(userId: string): Promise<number> {
+  const { rows } = await query<{ wissen_spent: number }>(
+    'SELECT COALESCE(wissen_spent, 0) AS wissen_spent FROM player_research WHERE user_id = $1',
+    [userId],
+  );
+  return rows[0]?.wissen_spent ?? 0;
 }
 
 // ── Typed Artefacts ──────────────────────────────────────────────────────

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -52,6 +52,7 @@ import {
   getPlayerResearch,
   getActiveResearch,
   getWissen,
+  getWissenSpent,
   getTypedArtefacts,
   getActiveAutopilotRoute,
   pauseAutopilotRoute,
@@ -1333,6 +1334,7 @@ export class SectorRoom extends Room<SectorRoomState> {
       const activeResearch = await getActiveResearch(auth.userId, 1);
       const activeResearch2 = await getActiveResearch(auth.userId, 2);
       const wissen = await getWissen(auth.userId);
+      const wissenSpent = await getWissenSpent(auth.userId);
       const typedArtefacts = await getTypedArtefacts(auth.userId);
       const labTier = getAcepLevel(acepXp.ausbau);
       client.send('researchState', {
@@ -1341,6 +1343,7 @@ export class SectorRoom extends Room<SectorRoomState> {
         activeResearch,
         activeResearch2,
         wissen,
+        wissenSpent,
         wissenRate: 0,
         typedArtefacts,
         labTier,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2046,7 +2046,7 @@ export const COCKPIT_PROGRAM_LABELS: Record<string, string> = {
 // --- Phase 5: Deep Systems ---
 
 // Fuel
-export const FUEL_COST_PER_UNIT = 0.1; // 0.1 credits per fuel unit (was 2)
+export const FUEL_COST_PER_UNIT = 0.01; // 0.01 credits per fuel unit → 100 fuel = 1 credit
 export const FUEL_MIN_TANK = 1_000; // minimum tank size regardless of hull+modules
 export const FREE_REFUEL_MAX_SHIPS = 3;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1228,6 +1228,7 @@ export interface ResearchState {
   unlockedModules: string[];
   blueprints: string[];
   wissen?: number;
+  wissenSpent?: number;
 }
 
 // --- Admin Messages ---


### PR DESCRIPTION
## Summary

### #334 — Admin: edit position by quadrant
Player detail panel in admin console now shows **Quad: [X] [Y] Sektor: [X] [Y]** inputs instead of raw global coords. Calculates global position as `qx * 500 + sx`. Toast confirms both quadrant/sector and global coords on save.

### #335 — Fuel ist zu teuer
- `FUEL_COST_PER_UNIT`: `0.1` → `0.01` (100 fuel now costs 1 credit)
- Refuel slider: `min=100`, `step=100` — fuel sold in 100-unit increments only

### #336 — Wissen wird nicht angezeigt
- Migration 064: adds `wissen_spent INTEGER DEFAULT 0` to `player_research`
- `deductWissen` now also increments `wissen_spent`
- `researchState` message includes `wissenSpent`
- All three spend screens show **`WISSEN: 53 / [ 259 ]`** format:
  - TechTreeCanvas (header bar)
  - TechTreePanel (sidebar)
  - AcepTab (above XP paths)

## Test plan
- [ ] Admin: open player detail → Quad+Sektor inputs visible with current position
- [ ] Admin: set position to Q(1,0) S(10,5) → player teleports to sector (510, 5)
- [ ] Refuel slider: min 100, steps by 100, cost 1 CR per 100 fuel
- [ ] Open TECH screen → shows `WISSEN: X / [ Y ]`
- [ ] Open ACEP screen → shows `WISSEN: X / [ Y ]`
- [ ] Spend wissen on tech node → spent counter increments

Closes #334, #335, #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)