### PR TITLE
fix: bugs #349 #352 #354 #355 — cockpit panel, kontor, construction radar, quest state

### DIFF
--- a/packages/client/src/canvas/RadarRenderer.ts
+++ b/packages/client/src/canvas/RadarRenderer.ts
@@ -16,6 +16,7 @@ import type {
   Bookmark,
   Quest,
   CivShip,
+  ConstructionSiteState,
 } from '@void-sector/shared';
 import type { PlayerPresence, TrackedQuest } from '../state/gameSlice';
 import type { JumpAnimationState } from './JumpAnimation';
@@ -104,6 +105,7 @@ interface RadarState {
   /** Slow flight path from current position to target — drawn as dashed overlay */
   slowFlightPath?: Array<{ x: number; y: number }>;
   sectorWrecks?: Record<string, { tier: number; size: string }>;
+  constructionSites?: ConstructionSiteState[];
 }
 
 function easeInOutCubic(t: number): number {
@@ -286,6 +288,20 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
           ctx.strokeStyle = `rgba(0,120,255,${alpha})`;
           ctx.lineWidth = 2;
           ctx.strokeRect(cellX - CELL_W / 2 + 3, cellY - CELL_H / 2 + 3, CELL_W - 6, CELL_H - 6);
+        }
+      }
+
+      // Construction site marker: cyan pulsing ⚙ dot for sectors with an active construction site
+      if (state.constructionSites && !isPlayer) {
+        const hasSite = state.constructionSites.some((c) => c.sectorX === sx && c.sectorY === sy);
+        if (hasSite) {
+          const t = state.animTime ?? 0;
+          const alpha = 0.5 + 0.5 * Math.sin(t / 800);
+          ctx.fillStyle = `rgba(0,255,200,${alpha})`;
+          ctx.font = `${coordSize}px 'Share Tech Mono', monospace`;
+          ctx.textAlign = 'right';
+          ctx.textBaseline = 'top';
+          ctx.fillText('⚙', cellX + CELL_W / 2 - 2, cellY - CELL_H / 2 + 2);
         }
       }
 

--- a/packages/client/src/components/CockpitLayout.tsx
+++ b/packages/client/src/components/CockpitLayout.tsx
@@ -20,7 +20,7 @@ import { AcepDetailPanel } from './AcepDetailPanel';
 import { WreckPanel } from './WreckPanel';
 import { SectorInfo, StatusBar } from './HUD';
 import { NavControls } from './NavControls';
-import { ShipBlock, CargoBlock } from './ShipBlock';
+import { ShipBlock, CargoBlock, StatsBlock } from './ShipBlock';
 import { CombatStatusPanel } from './CombatStatusPanel';
 import { SlateControls } from './SlateControls';
 import { CommsScreen } from './CommsScreen';
@@ -195,6 +195,7 @@ export function CockpitLayout({ renderScreen }: CockpitLayoutProps) {
           <div className="nav-zone-b">
             <ShipBlock />
             <CargoBlock />
+            <StatsBlock />
             <CombatStatusPanel />
             <SlateControls />
           </div>

--- a/packages/client/src/components/QuestsScreen.tsx
+++ b/packages/client/src/components/QuestsScreen.tsx
@@ -263,14 +263,16 @@ function JournalTab() {
         const typePrefix = (q.templateId as string)?.split('_')[0] ?? '';
         const typeLabel = QUEST_TYPE_LABELS[typePrefix] ?? typePrefix.toUpperCase();
         const canTrack = isTracked || trackedQuests.length < MAX_TRACKED;
+        const stateColor = allDone ? '#00FF88' : '#4488FF';
+        const stateLabel = allDone ? 'ABGABE' : 'IN ARBEIT';
         return (
           <div
             key={q.id}
             style={{
-              border: `1px solid ${isTracked ? 'rgba(0,120,255,0.6)' : 'rgba(255,176,0,0.25)'}`,
+              border: `1px solid ${allDone ? 'rgba(0,255,136,0.5)' : isTracked ? 'rgba(68,136,255,0.6)' : 'rgba(255,176,0,0.25)'}`,
               marginBottom: 4,
               padding: '4px 6px',
-              background: isTracked ? 'rgba(0,60,180,0.06)' : 'transparent',
+              background: allDone ? 'rgba(0,255,136,0.04)' : isTracked ? 'rgba(0,60,180,0.06)' : 'transparent',
             }}
           >
             <div
@@ -302,11 +304,24 @@ function JournalTab() {
               </button>
             </div>
             <div
-              style={{ color: 'rgba(255,176,0,0.45)', fontSize: '0.6rem', marginTop: 2 }}
+              style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.6rem', marginTop: 2 }}
             >
-              {doneCount}/{q.objectives.length} {t('status.objectives')}
+              <span
+                style={{
+                  color: stateColor,
+                  border: `1px solid ${stateColor}`,
+                  padding: '0 3px',
+                  letterSpacing: '0.05em',
+                  opacity: 0.9,
+                }}
+              >
+                {stateLabel}
+              </span>
+              <span style={{ color: 'rgba(255,176,0,0.45)' }}>
+                {doneCount}/{q.objectives.length} {t('status.objectives')}
+              </span>
               {q.npcFactionId && (
-                <span style={{ marginLeft: 6, opacity: 0.7 }}>
+                <span style={{ color: 'rgba(255,176,0,0.45)', opacity: 0.7 }}>
                   [{(q.npcFactionId as string).toUpperCase()}]
                 </span>
               )}

--- a/packages/client/src/components/RadarCanvas.tsx
+++ b/packages/client/src/components/RadarCanvas.tsx
@@ -83,6 +83,7 @@ export function RadarCanvas({ onSectorTap }: RadarCanvasProps = {}) {
       miningActive: !!state.mining?.active,
       civShips: state.civShips,
       sectorWrecks: state.sectorWrecks,
+      constructionSites: state.constructionSites,
       slowFlightPath:
         state.slowFlightActive && state.autopilot?.active
           ? [

--- a/packages/client/src/components/ShipBlock.tsx
+++ b/packages/client/src/components/ShipBlock.tsx
@@ -104,6 +104,24 @@ export function ShipBlock() {
   );
 }
 
+export function StatsBlock() {
+  const ship = useStore((s) => s.ship);
+  if (!ship) return null;
+  const { stats } = ship;
+  return (
+    <div className="nav-block">
+      <div className="nav-block-header">── COCKPIT ──</div>
+      <div style={dim}>FUEL MAX: <span style={{ color: 'var(--color-primary)' }}>{stats.fuelMax.toLocaleString()}</span></div>
+      <div style={dim}>CARGO MAX: <span style={{ color: 'var(--color-primary)' }}>{stats.cargoCap}</span></div>
+      <div style={dim}>JUMP RANGE: <span style={{ color: 'var(--color-primary)' }}>{stats.jumpRange}</span></div>
+      {(stats as any).hyperdriveRange > 0 && (
+        <div style={dim}>HYPER: <span style={{ color: '#4488FF' }}>{(stats as any).hyperdriveRange} CHG</span></div>
+      )}
+      <div style={dim}>SCANNER: <span style={{ color: 'var(--color-primary)' }}>LV.{stats.scannerLevel}</span></div>
+    </div>
+  );
+}
+
 export function CargoBlock() {
   const cargo            = useStore((s) => s.cargo);
   const ship             = useStore((s) => s.ship);

--- a/packages/client/src/components/TradeScreen.tsx
+++ b/packages/client/src/components/TradeScreen.tsx
@@ -9,6 +9,7 @@ import {
   NPC_PRICES,
   NPC_BUY_SPREAD,
   NPC_SELL_SPREAD,
+  MODULES,
 } from '@void-sector/shared';
 
 const NPC_COLUMN_MAX_HEIGHT = '220px';
@@ -53,7 +54,8 @@ export function TradeScreen() {
   const tradeMessage = useStore((s) => s.tradeMessage);
   const setTradeMessage = useStore((s) => s.setTradeMessage);
   const [amount, setAmount] = useState(1);
-  const [tab, setTab] = useState<'market' | 'slates' | 'routes' | 'kontor'>('market');
+  const [tab, setTab] = useState<'npc' | 'market' | 'slates' | 'routes' | 'kontor'>('npc');
+  const [npcSubTab, setNpcSubTab] = useState<'resources' | 'modules'>('resources');
 
   const tradingPost = baseStructures.find((s: any) => s.type === 'trading_post');
   const tier = tradingPost?.tier ?? 0;
@@ -138,7 +140,7 @@ export function TradeScreen() {
 
       <div style={{ display: 'flex', gap: 4, marginBottom: 8, flexWrap: 'wrap' }}>
         <button style={tabStyle(tab === 'npc')} onClick={() => setTab('npc')}>
-          NPC {t('tabs.trade')}
+          {isStation ? 'KONTOR' : `NPC ${t('tabs.trade')}`}
         </button>
         {!isStation && tier >= 2 && (
           <button style={tabStyle(tab === 'market')} onClick={() => setTab('market')}>
@@ -228,6 +230,14 @@ export function TradeScreen() {
               <div style={{ fontSize: '0.6rem', opacity: 0.45, marginBottom: 6, letterSpacing: '0.05em' }}>
                 * Preise dynamisch (abhängig vom Lagerbestand)
               </div>
+              <div style={{ display: 'flex', gap: 4, marginBottom: 8 }}>
+                <button style={tabStyle(npcSubTab === 'resources')} onClick={() => setNpcSubTab('resources')}>
+                  RESSOURCEN
+                </button>
+                <button style={tabStyle(npcSubTab === 'modules')} onClick={() => setNpcSubTab('modules')}>
+                  MODULE
+                </button>
+              </div>
               <div
                 style={{
                   display: 'grid',
@@ -248,7 +258,9 @@ export function TradeScreen() {
                     STATION LISTING
                   </div>
                   <div style={{ overflowY: 'auto', maxHeight: NPC_COLUMN_MAX_HEIGHT }}>
-                    {npcStationData.inventory.map((item) => {
+                    {npcStationData.inventory.filter((item) =>
+                      npcSubTab === 'modules' ? item.itemType in MODULES : !(item.itemType in MODULES)
+                    ).map((item) => {
                       const filled =
                         item.maxStock > 0 ? Math.round((item.stock / item.maxStock) * 10) : 0;
                       const empty = 10 - filled;
@@ -323,7 +335,9 @@ export function TradeScreen() {
                     ON BOARD ({cargoTotal}/{cargoCap})
                   </div>
                   <div style={{ overflowY: 'auto', maxHeight: NPC_COLUMN_MAX_HEIGHT }}>
-                    {npcStationData.inventory.map((item) => {
+                    {npcStationData.inventory.filter((item) =>
+                      npcSubTab === 'modules' ? item.itemType in MODULES : !(item.itemType in MODULES)
+                    ).map((item) => {
                       // itemType is always a resource key for NPC station inventory items
                       const playerAmount =
                         cargo[item.itemType as 'ore' | 'gas' | 'crystal'] ?? 0;


### PR DESCRIPTION
## Summary

- **#349**: Add `StatsBlock` to cockpit sec5 (nav zone) showing FUEL MAX, CARGO MAX, JUMP RANGE, HYPER charge, SCANNER level
- **#352**: Rename NPC Handel tab → **KONTOR** at stations; add RESSOURCEN/MODULE sub-tabs to filter station inventory
- **#354**: Construction site markers (pulsing ⚙) rendered on radar for active build sites
- **#355**: Color-coded state badge on quest journal cards — blue **IN ARBEIT** (in progress) / green **ABGABE** (ready to turn in)

## Test plan

- [ ] Open cockpit sec5, verify COCKPIT stats block shows ship stats
- [ ] At a station, open TRADE → tab should read KONTOR; verify RESSOURCEN/MODULE sub-tabs filter inventory correctly
- [ ] Place a construction site, open NAV-COM radar — ⚙ icon should pulse on that sector
- [ ] Open QUESTS → LOG tab, verify active quests show blue/green state badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)