### PR TITLE
fix: area scan AP display — correct scanner level + rounded regen (#367)

### DIFF
--- a/packages/client/src/components/HUD.tsx
+++ b/packages/client/src/components/HUD.tsx
@@ -121,7 +121,7 @@ export function StatusBar() {
         </span>
         {ap && (
           <span style={{ fontSize: '0.75rem', color: 'var(--color-dim)' }}>
-            {ap.regenPerSecond}/s {isFull ? <span style={{ color: '#00FF88' }}>FULL</span> : `IN ${secondsToFull}s`}
+            {Math.round(ap.regenPerSecond * 100) / 100}/s {isFull ? <span style={{ color: '#00FF88' }}>FULL</span> : `IN ${secondsToFull}s`}
           </span>
         )}
       </div>

--- a/packages/client/src/components/NavControls.tsx
+++ b/packages/client/src/components/NavControls.tsx
@@ -19,6 +19,8 @@ export function NavControls() {
   const autopilot = useStore((s) => s.autopilot);
   const hyperdrive = useStore((s) => s.hyperdriveState);
   const scanPending = useStore((s) => s.scanPending);
+  const ship = useStore((s) => s.ship);
+  const scannerLevel = ship?.stats?.scannerLevel ?? 1;
 
   if (autopilot?.active) {
     return (
@@ -49,7 +51,8 @@ export function NavControls() {
   // AP cost feasibility checks
   const canJump = ap && ap.current >= AP_COSTS.jump;
   const canLocalScan = ap && ap.current >= AP_COSTS_LOCAL_SCAN;
-  const canAreaScan = ap && ap.current >= (AP_COSTS_BY_SCANNER[1]?.areaScan ?? 3);
+  const areaScanCost = AP_COSTS_BY_SCANNER[scannerLevel]?.areaScan ?? areaScanCost;
+  const canAreaScan = ap && ap.current >= areaScanCost;
 
   const insufficientStyle = { borderColor: 'var(--color-danger)', opacity: 0.5 };
   const miningDisabledStyle = isMining
@@ -140,7 +143,7 @@ export function NavControls() {
           </button>
           <button
             className="vs-btn"
-            title={`Area Scan: ${AP_COSTS_BY_SCANNER[1]?.areaScan ?? 3} AP`}
+            title={`Area Scan: ${areaScanCost} AP`}
             onClick={() => network.sendAreaScan()}
             disabled={jumpPending || isMining || scanPending || !canAreaScan}
             style={
@@ -154,7 +157,7 @@ export function NavControls() {
             {isMining
               ? btnDisabled(t('actions.scan'), t('reasons.miningActive'))
               : !canAreaScan
-                ? btnDisabled(t('actions.scan'), t('reasons.apCost', { n: AP_COSTS_BY_SCANNER[1]?.areaScan ?? 3 }))
+                ? btnDisabled(t('actions.scan'), t('reasons.apCost', { n: areaScanCost }))
                 : btn('AREA SCAN')}
           </button>
         </div>


### PR DESCRIPTION
## Summary
- NavControls: use actual `ship.stats.scannerLevel` instead of hardcoded level 1 for area scan cost display
- HUD: round `regenPerSecond` display to 2 decimal places (avoids long floats like `0.5800000001`)
- Area scan button tooltip/disabled text now shows correct AP cost for player's scanner level

Fixes #367