### PR TITLE
fix: #369 jumpgate blockers — build/link live update, owner travel, custom slate

### DIFF
--- a/packages/client/src/components/PlayerGatePanel.tsx
+++ b/packages/client/src/components/PlayerGatePanel.tsx
@@ -191,6 +191,37 @@ function OwnerView({ gate, destinations, gateSlates }: OwnerViewProps) {
         </div>
       )}
 
+      {/* Travel (owner can also use their own gate) */}
+      {destinations.length > 0 && (
+        <div style={{ marginTop: 4 }}>
+          <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.1em' }}>REISEN:</div>
+          {destinations.map((dest) => (
+            <div
+              key={dest.gateId}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                fontSize: '0.75rem',
+                padding: '2px 0',
+              }}
+            >
+              <span style={{ color: '#00BFFF' }}>
+                ({innerCoord(dest.sectorX)}, {innerCoord(dest.sectorY)}) — {dest.totalCost} CR
+                {dest.hops > 1 ? ` (${dest.hops} Hops)` : ''}
+              </span>
+              <button
+                className="vs-btn"
+                style={{ fontSize: '0.65rem', padding: '1px 6px' }}
+                onClick={() => network.sendUsePlayerGate(gate.id, dest.gateId)}
+              >
+                [SPRINGEN]
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Actions */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 4 }}>
         <button

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -293,6 +293,8 @@ class GameNetwork {
         }
         if (data.success && data.newSector) {
           const store = useStore.getState();
+          // Clear stale gate info — server will re-send if new sector has a player gate
+          store.setPlayerGateInfo(null);
           const dx = data.newSector.x - store.position.x;
           const dy = data.newSector.y - store.position.y;
           store.startJumpAnimation(dx, dy);
@@ -1269,6 +1271,8 @@ class GameNetwork {
       }) => {
         const store = useStore.getState();
         if (data.success && data.newSector) {
+          // Clear stale gate info — server will re-send if new sector has a player gate
+          store.setPlayerGateInfo(null);
           const dx = data.newSector.x - store.position.x;
           const dy = data.newSector.y - store.position.y;
           store.startJumpAnimation(dx, dy);

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -718,7 +718,7 @@ export async function createDataSlate(
 
 export async function getPlayerSlates(playerId: string): Promise<any[]> {
   const result = await query(
-    `SELECT ds.id, ds.creator_id, ds.owner_id, ds.slate_type, ds.sector_data, ds.status, ds.created_at,
+    `SELECT ds.id, ds.creator_id, ds.owner_id, ds.slate_type, ds.sector_data, ds.custom_data, ds.status, ds.created_at,
             p.username as creator_name
      FROM data_slates ds
      JOIN players p ON p.id = ds.creator_id
@@ -727,6 +727,19 @@ export async function getPlayerSlates(playerId: string): Promise<any[]> {
     [playerId],
   );
   return result.rows;
+}
+
+export async function createCustomDataSlate(
+  creatorId: string,
+  customData: Record<string, unknown>,
+): Promise<{ id: string }> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO data_slates (creator_id, owner_id, slate_type, sector_data, custom_data)
+     VALUES ($1, $1, 'custom', '[]'::jsonb, $2::jsonb)
+     RETURNING id`,
+    [creatorId, JSON.stringify(customData)],
+  );
+  return result.rows[0];
 }
 
 export async function getSlateById(slateId: string): Promise<any | null> {

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -107,6 +107,7 @@ import type {
   UpgradeStructureMessage,
   PlaceOrderMessage,
   CreateSlateMessage,
+  CreateCustomSlateMessage,
   ActivateSlateMessage,
   NpcBuybackMessage,
   ListSlateMessage,
@@ -319,6 +320,8 @@ export class SectorRoom extends Room<SectorRoomState> {
       applyReputationChange: null as any,
       applyXpGain: null as any,
       contributeToCommunityQuest: null as any,
+      detectAndSendPlayerGate: null as any,
+      onResourceSoldAtStation: null as any,
       deductAP: async (playerId: string, cost: number): Promise<boolean> => {
         const ap = await getAPState(playerId);
         const newAP = spendAP(ap, cost);
@@ -362,6 +365,9 @@ export class SectorRoom extends Room<SectorRoomState> {
     );
     this.serviceCtx.contributeToCommunityQuest = this.communityQuests.contribute.bind(
       this.communityQuests,
+    );
+    this.serviceCtx.detectAndSendPlayerGate = this.navigation.detectAndSendPlayerGate.bind(
+      this.navigation,
     );
 
     // ── Navigation ──────────────────────────────────────────────────
@@ -810,6 +816,9 @@ export class SectorRoom extends Room<SectorRoomState> {
     });
     this.onMessage('createSlateFromScan', async (client) => {
       await this.world.handleCreateSlateFromScan(client);
+    });
+    this.onMessage('createCustomSlate', async (client, data: CreateCustomSlateMessage) => {
+      await this.world.handleCreateCustomSlate(client, data);
     });
     this.onMessage('activateSlate', async (client, data: ActivateSlateMessage) => {
       await this.world.handleActivateSlate(client, data);

--- a/packages/server/src/rooms/services/ServiceContext.ts
+++ b/packages/server/src/rooms/services/ServiceContext.ts
@@ -83,4 +83,7 @@ export interface ServiceContext {
 
   // AP management
   deductAP: (playerId: string, cost: number) => Promise<boolean>;
+
+  // Navigation helpers (cross-service)
+  detectAndSendPlayerGate: (client: Client, sectorX: number, sectorY: number) => Promise<void>;
 }

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -19,6 +19,7 @@ import type {
   ClearBookmarkMessage,
   MineableResourceType,
   StructureType,
+  CreateCustomSlateMessage,
 } from '@void-sector/shared';
 
 import { logger } from '../../utils/logger.js';
@@ -60,6 +61,8 @@ import {
   NPC_PRICES,
   NPC_BUY_SPREAD,
   NPC_SELL_SPREAD,
+  CUSTOM_SLATE_AP_COST,
+  CUSTOM_SLATE_CREDIT_COST,
 } from '@void-sector/shared';
 import {
   getAPState,
@@ -84,6 +87,7 @@ import {
   cancelTradeOrder,
   fulfillTradeOrder,
   createDataSlate,
+  createCustomDataSlate,
   getPlayerSlates,
   getSlateById,
   deleteSlate,
@@ -600,6 +604,9 @@ export class WorldService {
     client.send('cargoUpdate', await getCargoState(auth.userId));
     client.send('creditsUpdate', { credits: await getPlayerCredits(auth.userId) });
     client.send('logEntry', `Jumpgate errichtet bei (${sx}, ${sy})`);
+
+    // Send gate info so PlayerGatePanel shows immediately after build
+    await this.ctx.detectAndSendPlayerGate(client, sx, sy);
   }
 
   // ── Jumpgate Upgrade / Dismantle / Toll ───────────────────────────
@@ -772,6 +779,7 @@ export class WorldService {
       ownerId: row.owner_id,
       slateType: row.slate_type,
       sectorData: row.sector_data,
+      customData: row.custom_data ?? undefined,
       status: row.status,
       createdAt: new Date(row.created_at).getTime(),
     };
@@ -881,6 +889,67 @@ export class WorldService {
       ap: currentAP.current,
     });
     client.send('apUpdate', currentAP);
+  }
+
+  async handleCreateCustomSlate(client: Client, data: CreateCustomSlateMessage): Promise<void> {
+    if (rejectGuest(client, 'Data Slates erstellen')) return;
+    const auth = client.auth as AuthPayload;
+
+    if (!data.label || typeof data.label !== 'string' || !data.label.trim()) {
+      client.send('createSlateResult', { success: false, error: 'Label required' });
+      return;
+    }
+
+    const ship = this.ctx.getShipForClient(client.sessionId);
+    const cargo = await getCargoState(auth.userId);
+    if (cargo.slates >= ship.memory) {
+      client.send('createSlateResult', { success: false, error: 'Memory full — no space for slate' });
+      return;
+    }
+
+    const ap = await getAPState(auth.userId);
+    const currentAP = calculateCurrentAP(ap, Date.now());
+    if (currentAP.current < CUSTOM_SLATE_AP_COST) {
+      client.send('createSlateResult', {
+        success: false,
+        error: `Not enough AP (need ${CUSTOM_SLATE_AP_COST})`,
+      });
+      return;
+    }
+
+    const credits = await getPlayerCredits(auth.userId);
+    if (credits < CUSTOM_SLATE_CREDIT_COST) {
+      client.send('createSlateResult', {
+        success: false,
+        error: `Not enough credits (need ${CUSTOM_SLATE_CREDIT_COST})`,
+      });
+      return;
+    }
+
+    // Deduct AP and credits
+    currentAP.current -= CUSTOM_SLATE_AP_COST;
+    await saveAPState(auth.userId, currentAP);
+    await deductCredits(auth.userId, CUSTOM_SLATE_CREDIT_COST);
+
+    // Create slate + add to cargo
+    const customData = {
+      label: data.label.trim(),
+      notes: data.notes,
+      coordinates: data.coordinates,
+      codes: data.codes,
+    };
+    const slate = await createCustomDataSlate(auth.userId, customData);
+    await addSlateToCargo(auth.userId);
+    const updatedCargo = await getCargoState(auth.userId);
+
+    client.send('createSlateResult', {
+      success: true,
+      slate: { id: slate.id, slateType: 'custom', sectorData: [], customData, status: 'available' },
+      cargo: updatedCargo,
+      ap: currentAP.current,
+    });
+    client.send('apUpdate', currentAP);
+    client.send('creditsUpdate', { credits: await getPlayerCredits(auth.userId) });
   }
 
   async handleCreateSlateFromScan(client: Client): Promise<void> {
@@ -1040,6 +1109,9 @@ export class WorldService {
     client.send('jumpgateLinkResult', { success: true });
     client.send('cargoUpdate', await getCargoState(auth.userId));
     client.send('logEntry', `Gate bei (${targetGate.sectorX}, ${targetGate.sectorY}) verknüpft`);
+
+    // Send updated gate info so PlayerGatePanel reflects the new link and destinations
+    await this.ctx.detectAndSendPlayerGate(client, sx, sy);
   }
 
   async handleUnlinkJumpgate(


### PR DESCRIPTION
## Summary
- **Blocker 2**: PlayerGatePanel now appears immediately after building a jumpgate (was missing `detectAndSendPlayerGate` call)
- **Blocker 3**: Stale `playerGateInfo` cleared on jump/gate-travel (prevents ghost gate panel in wrong sector)
- **Blocker 1**: Gate owner can now teleport via their own gate — added REISEN section with [SPRINGEN] to OwnerView
- **Blocker 4**: Custom slate creation (`createCustomSlate`) server handler added (was missing, crashed WebSocket)
- Wired `detectAndSendPlayerGate` into ServiceContext for cross-service access
- Added `createCustomDataSlate` DB function, `custom_data` column now returned in `getPlayerSlates`

## Test plan
- [x] Server tests pass (1447 passed, pre-existing failures unchanged)
- [x] Playtest: PlayerGatePanel appears immediately after gate build
- [x] Playtest: Gate linking updates panel with VERKNÜPFTE GATES
- [x] Playtest: [DISK 2AP/5CR] custom slate creation works without crash
- [ ] Verify owner [SPRINGEN] teleports to linked gate
- [ ] Verify gate info clears when leaving gate sector via normal jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)