### PR TITLE
fix: #376 mineAll resource display jumps back after depletion

### DIFF
--- a/packages/server/src/rooms/services/MiningService.ts
+++ b/packages/server/src/rooms/services/MiningService.ts
@@ -160,6 +160,9 @@ export class MiningService {
 
                 await saveMiningState(playerId, nextResult.state);
                 client.send('miningUpdate', nextResult.state);
+                // Send depleted sector data so client resource bars update
+                client.send('sectorData', sectorData);
+                client.send('cargoUpdate', await getCargoState(playerId));
                 this.setAutoStopTimer(
                   client, playerId,
                   nextResult.state.sectorYield,


### PR DESCRIPTION
## Summary
- When mineAll chains to next resource (e.g. crystal→ore), the early return skipped sending `sectorData` and `cargoUpdate`
- Client kept stale resource values (crystal=6) even though DB was correctly depleted to 0
- Fix: send `sectorData` and `cargoUpdate` before the early return in the mineAll chain path

## Test plan
- [ ] Mine crystal to 0 with mineAll active, verify display stays at 0 when switching to ore
- [ ] Verify cargo updates correctly during mineAll chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)