### PR TITLE
fix: rulebook #380 — AP costs, scan radii, generator regen, lab AP removal

### DIFF
--- a/packages/server/src/engine/__tests__/ap.test.ts
+++ b/packages/server/src/engine/__tests__/ap.test.ts
@@ -19,13 +19,13 @@ describe('AP engine', () => {
   });
 
   it('createAPState uses calculateApRegen when generator_mk1 present', () => {
-    // generator_mk1: apRegenPerSecond=0.20, powerLevel=high (multiplier=1.0), currentHp=maxHp=20
-    // expected: BASE_HULL_AP_REGEN + 0.20 * 1.0 * 1.0 = 0.08 + 0.20 = 0.28
+    // generator_mk1: apRegenPerSecond=2, powerLevel=high (multiplier=1.0), currentHp=maxHp=20
+    // expected: BASE_HULL_AP_REGEN + 2 * 1.0 * 1.0 = 0.1 + 2 = 2.1
     const modules: ShipModule[] = [
       { moduleId: 'generator_mk1', slotIndex: 0, source: 'standard', powerLevel: 'high', currentHp: 20 },
     ];
     const ap = createAPState(Date.now(), modules);
-    expect(ap.regenPerSecond).toBeCloseTo(BASE_HULL_AP_REGEN + 0.20);
+    expect(ap.regenPerSecond).toBeCloseTo(BASE_HULL_AP_REGEN + 2);
   });
 
   it('calculateCurrentAP regenerates over time', () => {

--- a/packages/server/src/engine/__tests__/commands-slates.test.ts
+++ b/packages/server/src/engine/__tests__/commands-slates.test.ts
@@ -29,9 +29,9 @@ describe('validateCreateSlate', () => {
   });
 
   it('calculates area slate AP cost from scanner level', () => {
-    const result = validateCreateSlate({ ...baseState, scannerLevel: 2 }, 'area');
+    const result = validateCreateSlate({ ...baseState, ap: 10, scannerLevel: 2 }, 'area');
     expect(result.valid).toBe(true);
-    expect(result.apCost).toBe(SLATE_AP_COST_AREA + 1);
+    expect(result.apCost).toBe(SLATE_AP_COST_AREA + 2 * 2);
     expect(result.radius).toBe(SLATE_AREA_RADIUS[2]);
   });
 

--- a/packages/server/src/engine/__tests__/commands.test.ts
+++ b/packages/server/src/engine/__tests__/commands.test.ts
@@ -156,7 +156,7 @@ describe('validateAreaScan', () => {
     const ap = createAPState(now);
     const result = validateAreaScan(ap, 1);
     expect(result.valid).toBe(true);
-    expect(result.radius).toBe(3);
+    expect(result.radius).toBe(4);
     expect(result.cost).toBe(3);
   });
 
@@ -165,8 +165,8 @@ describe('validateAreaScan', () => {
     const ap = createAPState(now);
     const result = validateAreaScan(ap, 3);
     expect(result.valid).toBe(true);
-    expect(result.radius).toBe(9);
-    expect(result.cost).toBe(10);
+    expect(result.radius).toBe(12);
+    expect(result.cost).toBe(8);
   });
 
   it('fails with insufficient AP', () => {

--- a/packages/server/src/engine/__tests__/structures.test.ts
+++ b/packages/server/src/engine/__tests__/structures.test.ts
@@ -22,37 +22,31 @@ const fullCargo = {
 
 describe('validateLabUpgrade', () => {
   it('fails if no existing lab (tier 0)', () => {
-    const r = validateLabUpgrade(0, 20, 9999, fullCargo);
+    const r = validateLabUpgrade(0, 9999, fullCargo);
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/no.*lab/i);
   });
 
   it('fails if already at max tier (5)', () => {
-    const r = validateLabUpgrade(5, 20, 9999, fullCargo);
+    const r = validateLabUpgrade(5, 9999, fullCargo);
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/max/i);
   });
 
-  it('fails if insufficient AP (< 20)', () => {
-    const r = validateLabUpgrade(1, 10, 9999, fullCargo);
-    expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/AP/i);
-  });
-
   it('fails if insufficient credits', () => {
-    const r = validateLabUpgrade(1, 20, 0, fullCargo);
+    const r = validateLabUpgrade(1, 0, fullCargo);
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/credits/i);
   });
 
   it('fails if insufficient ore', () => {
-    const r = validateLabUpgrade(1, 20, 9999, { ...fullCargo, ore: 0 });
+    const r = validateLabUpgrade(1, 9999, { ...fullCargo, ore: 0 });
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/ore/i);
   });
 
   it('succeeds for valid upgrade from tier 1 to 2', () => {
-    const r = validateLabUpgrade(1, 20, 9999, fullCargo);
+    const r = validateLabUpgrade(1, 9999, fullCargo);
     expect(r.valid).toBe(true);
     expect(r.targetTier).toBe(2);
     expect(r.costs).toBeDefined();

--- a/packages/server/src/engine/commands.ts
+++ b/packages/server/src/engine/commands.ts
@@ -331,7 +331,7 @@ interface CreateSlateResult {
 
 export function validateCreateSlate(state: CreateSlateState, slateType: string): CreateSlateResult {
   const apCost =
-    slateType === 'sector' ? SLATE_AP_COST_SECTOR : SLATE_AP_COST_AREA + (state.scannerLevel - 1);
+    slateType === 'sector' ? SLATE_AP_COST_SECTOR : SLATE_AP_COST_AREA + state.scannerLevel * 2;
 
   if (state.ap < apCost) {
     return { valid: false, error: `Not enough AP (need ${apCost}, have ${state.ap})` };
@@ -539,7 +539,6 @@ export function getReputationTier(reputation: number): string {
 
 export function validateLabUpgrade(
   currentLabTier: number,
-  currentAP: number,
   credits: number,
   cargo: { ore: number; crystal: number },
 ): {
@@ -556,9 +555,6 @@ export function validateLabUpgrade(
   const costs = RESEARCH_LAB_UPGRADE_COSTS[targetTier];
   if (!costs) return { valid: false, error: 'Unknown upgrade tier' };
 
-  if (currentAP < 20) {
-    return { valid: false, error: `Insufficient AP (need 20, have ${Math.floor(currentAP)})` };
-  }
   if (credits < costs.credits) {
     return { valid: false, error: `Insufficient credits (need ${costs.credits})` };
   }

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -492,15 +492,13 @@ export class WorldService {
     const sx = this.ctx._px(client.sessionId);
     const sy = this.ctx._py(client.sessionId);
 
-    const [labTier, ap, cargo, credits] = await Promise.all([
+    const [labTier, cargo, credits] = await Promise.all([
       getResearchLabTier(auth.userId),
-      getAPState(auth.userId),
       getCargoState(auth.userId),
       getPlayerCredits(auth.userId),
     ]);
 
-    const currentAP = calculateCurrentAP(ap, Date.now());
-    const result = validateLabUpgrade(labTier, currentAP.current, credits, cargo);
+    const result = validateLabUpgrade(labTier, credits, cargo);
 
     if (!result.valid) {
       client.send('error', { code: 'LAB_UPGRADE_FAIL', message: result.error! });
@@ -511,8 +509,6 @@ export class WorldService {
     await deductCredits(auth.userId, result.costs!.credits);
     await removeFromInventory(auth.userId, 'resource', 'ore', result.costs!.ore);
     await removeFromInventory(auth.userId, 'resource', 'crystal', result.costs!.crystal);
-    const newAP = { ...currentAP, current: currentAP.current - 20 };
-    await saveAPState(auth.userId, newAP);
 
     // Upgrade the lab at player's current position
     const newTier = await upgradeResearchLabTier(auth.userId, sx, sy);
@@ -525,7 +521,6 @@ export class WorldService {
     }
 
     client.send('labUpgradeResult', { success: true, newTier });
-    client.send('apUpdate', newAP);
     const updatedCargo = await getCargoState(auth.userId);
     client.send('cargoUpdate', updatedCargo);
   }

--- a/packages/server/src/rooms/services/__tests__/ShipService.test.ts
+++ b/packages/server/src/rooms/services/__tests__/ShipService.test.ts
@@ -59,8 +59,8 @@ describe('new ship generator_mk1 initialization', () => {
       { moduleId: 'generator_mk1', slotIndex: 0, source: 'standard', powerLevel: 'high', currentHp: 20 },
     ];
     const regen = calculateApRegen(modules);
-    // generator_mk1 has apRegenPerSecond: 0.20, so total = 0.08 + 0.20 = 0.28
-    expect(regen).toBeCloseTo(BASE_HULL_AP_REGEN + 0.20);
+    // generator_mk1 has apRegenPerSecond: 2, so total = 0.1 + 2 = 2.1
+    expect(regen).toBeCloseTo(BASE_HULL_AP_REGEN + 2);
     expect(regen).toBeGreaterThan(BASE_HULL_AP_REGEN);
   });
 });

--- a/packages/shared/src/__tests__/generatorModules.test.ts
+++ b/packages/shared/src/__tests__/generatorModules.test.ts
@@ -45,8 +45,8 @@ describe('new constants', () => {
     expect(MODULE_EP_COSTS['weapon']!['off']).toBe(0);
   });
 
-  it('BASE_HULL_AP_REGEN is 0.08', () => {
-    expect(BASE_HULL_AP_REGEN).toBeCloseTo(0.08);
+  it('BASE_HULL_AP_REGEN is 0.1', () => {
+    expect(BASE_HULL_AP_REGEN).toBeCloseTo(0.1);
   });
 });
 
@@ -57,13 +57,13 @@ describe('generator modules', () => {
     expect(g.category).toBe('generator');
     expect(g.tier).toBe(1);
     expect(g.effects.generatorEpPerRound).toBe(6);
-    expect(g.effects.apRegenPerSecond).toBeCloseTo(0.20);
+    expect(g.effects.apRegenPerSecond).toBeCloseTo(2);
     expect(g.maxHp).toBe(20);
   });
 
-  it('generator_mk5 has 18 EP/round and 1.0 AP/s', () => {
+  it('generator_mk5 has 18 EP/round and 10 AP/s', () => {
     expect(MODULES['generator_mk5'].effects.generatorEpPerRound).toBe(18);
-    expect(MODULES['generator_mk5'].effects.apRegenPerSecond).toBeCloseTo(1.0);
+    expect(MODULES['generator_mk5'].effects.apRegenPerSecond).toBeCloseTo(10);
   });
 
   it('repair_mk1 exists with repair stats', () => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -35,11 +35,11 @@ export const AP_COSTS = {
 };
 
 export const AP_COSTS_BY_SCANNER: Record<number, { areaScan: number; areaScanRadius: number }> = {
-  1: { areaScan: 3, areaScanRadius: 3 },
-  2: { areaScan: 6, areaScanRadius: 6 },
-  3: { areaScan: 10, areaScanRadius: 9 },
-  4: { areaScan: 14, areaScanRadius: 12 },
-  5: { areaScan: 18, areaScanRadius: 15 },
+  1: { areaScan: 3, areaScanRadius: 4 },
+  2: { areaScan: 5, areaScanRadius: 8 },
+  3: { areaScan: 8, areaScanRadius: 12 },
+  4: { areaScan: 14, areaScanRadius: 16 },
+  5: { areaScan: 18, areaScanRadius: 20 },
 };
 
 export const AP_COSTS_LOCAL_SCAN = 1;
@@ -473,7 +473,7 @@ export const MODULE_EP_COSTS: Partial<Record<ModuleCategory, Record<string, numb
 };
 
 /** Basis AP/s des Schiffs ohne Generator */
-export const BASE_HULL_AP_REGEN = 0.08;
+export const BASE_HULL_AP_REGEN = 0.1;
 
 /** Power-Level-Multiplikatoren für AP-Regen und EP-Output */
 export const POWER_LEVEL_MULTIPLIERS: Record<string, number> = {
@@ -488,7 +488,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
     name: 'FUSION CELL MK.I', displayName: 'FUSION MK.I',
     primaryEffect: { stat: 'generatorEpPerRound', delta: 6, label: 'EP/Runde +6' },
     secondaryEffects: [],
-    effects: { generatorEpPerRound: 6, apRegenPerSecond: 0.20 } as any,
+    effects: { generatorEpPerRound: 6, apRegenPerSecond: 2 } as any,
     cost: { credits: 150, ore: 15 },
     maxHp: 20, isUnique: true, acepPaths: ['ausbau'] as any,
   },
@@ -497,7 +497,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
     name: 'FUSION CELL MK.II', displayName: 'FUSION MK.II',
     primaryEffect: { stat: 'generatorEpPerRound', delta: 9, label: 'EP/Runde +9' },
     secondaryEffects: [],
-    effects: { generatorEpPerRound: 9, apRegenPerSecond: 0.30 } as any,
+    effects: { generatorEpPerRound: 9, apRegenPerSecond: 4 } as any,
     cost: { credits: 400, ore: 30, crystal: 5 },
     maxHp: 35, isUnique: true, acepPaths: ['ausbau'] as any,
     prerequisite: 'generator_mk1',
@@ -507,7 +507,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
     name: 'FUSION CELL MK.III', displayName: 'FUSION MK.III',
     primaryEffect: { stat: 'generatorEpPerRound', delta: 12, label: 'EP/Runde +12' },
     secondaryEffects: [],
-    effects: { generatorEpPerRound: 12, apRegenPerSecond: 0.50 } as any,
+    effects: { generatorEpPerRound: 12, apRegenPerSecond: 6 } as any,
     cost: { credits: 900, ore: 50, crystal: 15 },
     maxHp: 55, isUnique: true, acepPaths: ['ausbau'] as any,
     prerequisite: 'generator_mk2',
@@ -516,8 +516,8 @@ export const MODULES: Record<string, ModuleDefinition> = {
     id: 'generator_mk4', category: 'generator', tier: 4,
     name: 'FUSION CELL MK.IV', displayName: 'FUSION MK.IV',
     primaryEffect: { stat: 'generatorEpPerRound', delta: 15, label: 'EP/Runde +15' },
-    secondaryEffects: [{ stat: 'apRegenPerSecond', delta: 0.70, label: 'AP/s +0.70' }],
-    effects: { generatorEpPerRound: 15, apRegenPerSecond: 0.70 } as any,
+    secondaryEffects: [{ stat: 'apRegenPerSecond', delta: 8, label: 'AP/s +8' }],
+    effects: { generatorEpPerRound: 15, apRegenPerSecond: 8 } as any,
     cost: { credits: 2000, ore: 80, crystal: 30, artefact: 1 },
     maxHp: 80, isUnique: true, acepPaths: ['ausbau'] as any,
     prerequisite: 'generator_mk3',
@@ -528,8 +528,8 @@ export const MODULES: Record<string, ModuleDefinition> = {
     id: 'generator_mk5', category: 'generator', tier: 5,
     name: 'FUSION CELL MK.V', displayName: 'FUSION MK.V',
     primaryEffect: { stat: 'generatorEpPerRound', delta: 18, label: 'EP/Runde +18' },
-    secondaryEffects: [{ stat: 'apRegenPerSecond', delta: 1.00, label: 'AP/s +1.00' }],
-    effects: { generatorEpPerRound: 18, apRegenPerSecond: 1.00 } as any,
+    secondaryEffects: [{ stat: 'apRegenPerSecond', delta: 10, label: 'AP/s +10' }],
+    effects: { generatorEpPerRound: 18, apRegenPerSecond: 10 } as any,
     cost: { credits: 4500, ore: 120, crystal: 60, artefact: 2 },
     maxHp: 110, isUnique: true, acepPaths: ['ausbau'] as any,
     prerequisite: 'generator_mk4',


### PR DESCRIPTION
## Summary
- Area-Scan AP: Lv.2 6→5, Lv.3 10→8
- Area-Scan Radii: Lv.1 3→4, Lv.2 6→8, Lv.3 9→12, Lv.4 12→16, Lv.5 15→20
- BASE_HULL_AP_REGEN: 0.08 → 0.1
- Generator AP/s: MK.I-V 0.20/0.30/0.50/0.70/1.00 → 2/4/6/8/10
- Data-Slate Area AP: 3+(level-1) → 3+level*2
- Lab-Upgrade: 20 AP Kosten entfernt

Fixes #380