### PR TITLE
fix: rulebook #393 — autopilot speed 800ms, UI symbol consistency

### DIFF
--- a/packages/server/src/engine/__tests__/autopilot.test.ts
+++ b/packages/server/src/engine/__tests__/autopilot.test.ts
@@ -450,12 +450,12 @@ describe('Autopilot Engine', () => {
   // --- Constants ---
 
   describe('constants', () => {
-    it('STEP_INTERVAL_MS is 100ms', () => {
-      expect(STEP_INTERVAL_MS).toBe(100);
+    it('STEP_INTERVAL_MS is 800ms', () => {
+      expect(STEP_INTERVAL_MS).toBe(800);
     });
 
-    it('STEP_INTERVAL_MIN_MS is 20ms', () => {
-      expect(STEP_INTERVAL_MIN_MS).toBe(20);
+    it('STEP_INTERVAL_MIN_MS is 100ms', () => {
+      expect(STEP_INTERVAL_MIN_MS).toBe(100);
     });
   });
 

--- a/packages/server/src/engine/__tests__/autopilotHandlers.test.ts
+++ b/packages/server/src/engine/__tests__/autopilotHandlers.test.ts
@@ -446,19 +446,19 @@ describe('autopilot completion', () => {
 describe('autopilot tick rate', () => {
   it('normal mode uses STEP_INTERVAL_MS', () => {
     const tickMs = STEP_INTERVAL_MS;
-    expect(tickMs).toBe(100);
+    expect(tickMs).toBe(800);
   });
 
   it('hyperjump mode scales tick by engine speed', () => {
     const speed = 3;
     const tickMs = Math.max(STEP_INTERVAL_MIN_MS, Math.floor(STEP_INTERVAL_MS / speed));
-    expect(tickMs).toBe(33);
+    expect(tickMs).toBe(266);
   });
 
   it('tick rate is clamped to STEP_INTERVAL_MIN_MS', () => {
     const speed = 10;
     const tickMs = Math.max(STEP_INTERVAL_MIN_MS, Math.floor(STEP_INTERVAL_MS / speed));
-    expect(tickMs).toBe(STEP_INTERVAL_MIN_MS); // 20
+    expect(tickMs).toBe(STEP_INTERVAL_MIN_MS); // 100
   });
 
   it('speed 0 falls back to normal interval', () => {

--- a/packages/server/src/engine/autopilot.ts
+++ b/packages/server/src/engine/autopilot.ts
@@ -217,9 +217,9 @@ export interface AutopilotSegment {
 }
 
 /** Default step interval in ms (for normal movement). */
-export const STEP_INTERVAL_MS = 100;
+export const STEP_INTERVAL_MS = 800;
 /** Minimum tick interval in ms (clamped for high-speed drives). */
-export const STEP_INTERVAL_MIN_MS = 20;
+export const STEP_INTERVAL_MIN_MS = 100;
 
 /**
  * Extract the next segment of moves from a path for one autopilot tick.

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2215,7 +2215,7 @@ export const ENGINE_SPEED: Record<string, number> = {
 // Research system
 export const RESEARCH_TICK_MS = 60_000; // 1 tick = 1 minute
 
-export const AUTOPILOT_STEP_MS = 100; // ms per sector during autopilot
+export const AUTOPILOT_STEP_MS = 800; // ms per sector during autopilot
 export const STALENESS_DIM_HOURS = 24; // dim sectors after 24h
 export const STALENESS_FADE_DAYS = 7; // coords-only after 7 days
 


### PR DESCRIPTION
## Summary
- Autopilot: STEP_INTERVAL_MS 100→800ms (sichtbare Schiffsbewegung)
- Autopilot: STEP_INTERVAL_MIN_MS 20→100ms (Hyperjump-Minimum)
- AUTOPILOT_STEP_MS 100→800ms (shared)
- Symbole bereits in #395 vereinheitlicht

Nicht in diesem PR (separate Issues):
- Autopilot Easy-Step-Editor (A→B mining, B→A sell, repeat) → eigenes Feature-Issue
- CRT-Scanlines/Vignette → kosmetisch, mittel
- willReadFrequently Canvas → bereits implementiert

Fixes #393