### PR TITLE
fix: rulebook #381 — fuel tank 10k, hyperdrive regen per tier, drive mk4/5 boost

### DIFF
--- a/packages/client/src/components/ShipStatusPanel.tsx
+++ b/packages/client/src/components/ShipStatusPanel.tsx
@@ -137,34 +137,30 @@ export function ShipStatusPanel() {
         </div>
       )}
 
-      {/* Fuel section */}
-      {tab === 'stats' && (
-        <>
-          <div style={hdr}>FUEL</div>
-          <div style={row}>
-            <span style={dim}>TANK</span>
-            <span style={pri}>
-              {fuel ? fuel.current.toLocaleString() : '—'}
-              <span style={{ opacity: 0.4 }}> / {(fuel?.max ?? stats.fuelMax).toLocaleString()}</span>
-            </span>
-          </div>
-          {fuel && (
-            <div style={{ height: 4, background: 'rgba(255,255,255,0.08)', borderRadius: 2, margin: '2px 0 4px' }}>
-              <div style={{
-                height: '100%',
-                width: `${Math.min(100, Math.round((fuel.current / fuel.max) * 100))}%`,
-                background: 'linear-gradient(90deg, #f97316, #fb923c)',
-                borderRadius: 2,
-                transition: 'width 0.3s',
-              }} />
-            </div>
-          )}
-          <div style={row}>
-            <span style={dim}>COST/SEKTOR</span>
-            <span style={pri}>{stats.fuelPerJump}</span>
-          </div>
-        </>
+      {/* Fuel section — always visible */}
+      <div style={hdr}>FUEL</div>
+      <div style={row}>
+        <span style={dim}>TANK</span>
+        <span style={pri}>
+          {fuel ? fuel.current.toLocaleString() : '—'}
+          <span style={{ opacity: 0.4 }}> / {(fuel?.max ?? stats.fuelMax).toLocaleString()}</span>
+        </span>
+      </div>
+      {fuel && (
+        <div style={{ height: 4, background: 'rgba(255,255,255,0.08)', borderRadius: 2, margin: '2px 0 4px' }}>
+          <div style={{
+            height: '100%',
+            width: `${Math.min(100, Math.round((fuel.current / fuel.max) * 100))}%`,
+            background: 'linear-gradient(90deg, #f97316, #fb923c)',
+            borderRadius: 2,
+            transition: 'width 0.3s',
+          }} />
+        </div>
       )}
+      <div style={row}>
+        <span style={dim}>COST/SEKTOR</span>
+        <span style={pri}>{stats.fuelPerJump}</span>
+      </div>
 
       {/* Hyperdrive charge */}
       {hasHyperdrive && (
@@ -183,7 +179,7 @@ export function ShipStatusPanel() {
               style={{ fontSize: '0.5rem', marginTop: 4, padding: '1px 6px', color: '#8888ff', borderColor: '#8888ff44' }}
               onClick={() => network.sendChargeHyperdrive()}
             >
-              [CHARGE: 1 GAS → +4]
+              [OVERPOWER: 1 GAS → +4]
             </button>
           )}
         </>

--- a/packages/shared/src/__tests__/hyperdriveCalc.test.ts
+++ b/packages/shared/src/__tests__/hyperdriveCalc.test.ts
@@ -179,33 +179,33 @@ describe('efficiency clamping in shipCalculator', () => {
 
   it('adds hyperdrive stats from drive_mk1', () => {
     const stats = calculateShipStats([{ moduleId: 'drive_mk1', slotIndex: 0 }]);
-    expect(stats.hyperdriveRange).toBe(4);
+    expect(stats.hyperdriveRange).toBe(32);
     expect(stats.hyperdriveSpeed).toBe(2);
-    expect(stats.hyperdriveRegen).toBe(1.0);
+    expect(stats.hyperdriveRegen).toBe(2.0);
     expect(stats.hyperdriveFuelEfficiency).toBe(0);
   });
 
   it('adds hyperdrive stats from drive_mk2', () => {
     const stats = calculateShipStats([{ moduleId: 'drive_mk2', slotIndex: 0 }]);
-    expect(stats.hyperdriveRange).toBe(8);
+    expect(stats.hyperdriveRange).toBe(64);
     expect(stats.hyperdriveSpeed).toBe(3);
-    expect(stats.hyperdriveRegen).toBe(1.5);
+    expect(stats.hyperdriveRegen).toBe(4.0);
     expect(stats.hyperdriveFuelEfficiency).toBeCloseTo(0.1);
   });
 
   it('adds hyperdrive stats from drive_mk3', () => {
     const stats = calculateShipStats([{ moduleId: 'drive_mk3', slotIndex: 0 }]);
-    expect(stats.hyperdriveRange).toBe(16);
+    expect(stats.hyperdriveRange).toBe(128);
     expect(stats.hyperdriveSpeed).toBe(5);
-    expect(stats.hyperdriveRegen).toBe(2.0);
+    expect(stats.hyperdriveRegen).toBe(6.0);
     expect(stats.hyperdriveFuelEfficiency).toBeCloseTo(0.2);
   });
 
   it('adds hyperdrive stats from void_drive', () => {
     const stats = calculateShipStats([{ moduleId: 'void_drive', slotIndex: 0 }]);
-    expect(stats.hyperdriveRange).toBe(30);
+    expect(stats.hyperdriveRange).toBe(192);
     expect(stats.hyperdriveSpeed).toBe(8);
-    expect(stats.hyperdriveRegen).toBe(3.0);
+    expect(stats.hyperdriveRegen).toBe(8.0);
     expect(stats.hyperdriveFuelEfficiency).toBeCloseTo(0.35);
   });
 });

--- a/packages/shared/src/__tests__/modules.test.ts
+++ b/packages/shared/src/__tests__/modules.test.ts
@@ -208,12 +208,12 @@ describe('Mining laser modules', () => {
 });
 
 describe('Drive mk4/mk5 specifics', () => {
-  it('drive_mk4 has hyperdriveRange 25', () => {
-    expect(MODULES['drive_mk4'].effects.hyperdriveRange).toBe(25);
+  it('drive_mk4 has hyperdriveRange 384', () => {
+    expect(MODULES['drive_mk4'].effects.hyperdriveRange).toBe(384);
   });
 
-  it('drive_mk5 has hyperdriveRange 50', () => {
-    expect(MODULES['drive_mk5'].effects.hyperdriveRange).toBe(50);
+  it('drive_mk5 has hyperdriveRange 768', () => {
+    expect(MODULES['drive_mk5'].effects.hyperdriveRange).toBe(768);
   });
 
   it('drive_mk4 costs 3 artefacts to purchase', () => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -609,7 +609,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
       engineSpeed: 1,
       hyperdriveRange: 32,
       hyperdriveSpeed: 2,
-      hyperdriveRegen: 4.0,
+      hyperdriveRegen: 2.0,
       fuelMax: 2_000,
     },
     cost: { credits: 100, ore: 10 },
@@ -661,7 +661,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
       engineSpeed: 3,
       hyperdriveRange: 128,
       hyperdriveSpeed: 5,
-      hyperdriveRegen: 4.0,
+      hyperdriveRegen: 6.0,
       hyperdriveFuelEfficiency: 0.2,
       fuelMax: 7_000,
     },
@@ -1037,7 +1037,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
       fuelPerJump: -30,
       hyperdriveRange: 192,
       hyperdriveSpeed: 8,
-      hyperdriveRegen: 4.0,
+      hyperdriveRegen: 8.0,
       hyperdriveFuelEfficiency: 0.35,
     },
     cost: { credits: 2000, artefact: 5 },
@@ -1173,7 +1173,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
     primaryEffect: { stat: 'jumpRange', delta: 4, label: 'Sprungweite +4' },
     secondaryEffects: [
       { stat: 'engineSpeed', delta: 4, label: 'Engine-Speed +4' },
-      { stat: 'hyperdriveRegen', delta: 2.5, label: 'Hyperdrive-Regen +2.5' },
+      { stat: 'hyperdriveRegen', delta: 8, label: 'Hyperdrive-Regen +8' },
       { stat: 'hyperdriveFuelEfficiency', delta: 0.3, label: 'Fuel-Effizienz +30%' },
       { stat: 'fuelMax', delta: 12_000, label: 'Fuel-Tank +12.000' },
     ],
@@ -1181,9 +1181,9 @@ export const MODULES: Record<string, ModuleDefinition> = {
       jumpRange: 4,
       apCostJump: -0.7,
       engineSpeed: 4,
-      hyperdriveRange: 256,
-      hyperdriveSpeed: 6,
-      hyperdriveRegen: 4.0,
+      hyperdriveRange: 384,
+      hyperdriveSpeed: 8,
+      hyperdriveRegen: 8.0,
       hyperdriveFuelEfficiency: 0.3,
       fuelMax: 12_000,
     },
@@ -1202,7 +1202,7 @@ export const MODULES: Record<string, ModuleDefinition> = {
     primaryEffect: { stat: 'jumpRange', delta: 6, label: 'Sprungweite +6' },
     secondaryEffects: [
       { stat: 'engineSpeed', delta: 5, label: 'Engine-Speed MAX' },
-      { stat: 'hyperdriveRegen', delta: 4.0, label: 'Hyperdrive-Regen +4.0' },
+      { stat: 'hyperdriveRegen', delta: 10, label: 'Hyperdrive-Regen +10' },
       { stat: 'hyperdriveFuelEfficiency', delta: 0.5, label: 'Fuel-Effizienz +50%' },
       { stat: 'fuelMax', delta: 18_000, label: 'Fuel-Tank +18.000' },
     ],
@@ -1210,9 +1210,9 @@ export const MODULES: Record<string, ModuleDefinition> = {
       jumpRange: 6,
       apCostJump: -1.0,
       engineSpeed: 5,
-      hyperdriveRange: 512,
-      hyperdriveSpeed: 10,
-      hyperdriveRegen: 4.0,
+      hyperdriveRange: 768,
+      hyperdriveSpeed: 12,
+      hyperdriveRegen: 10.0,
       hyperdriveFuelEfficiency: 0.5,
       fuelMax: 18_000,
     },
@@ -2061,7 +2061,7 @@ export const COCKPIT_PROGRAM_LABELS: Record<string, string> = {
 
 // Fuel
 export const FUEL_COST_PER_UNIT = 0.01; // 0.01 credits per fuel unit → 100 fuel = 1 credit
-export const FUEL_MIN_TANK = 1_000; // minimum tank size regardless of hull+modules
+export const FUEL_MIN_TANK = 10_000; // minimum tank size regardless of hull+modules
 export const FREE_REFUEL_MAX_SHIPS = 3;
 
 // Base ship stats (replaces hull-specific values after hull system removal)
@@ -2132,7 +2132,7 @@ export const FACTION_UPGRADE_TIERS: Record<
 // JumpGates
 export const JUMPGATE_CHANCE = 0.005; // natural bidirectional/wormhole gates (1 in 200 sectors)
 export const JUMPGATE_SALT = 777;
-export const JUMPGATE_FUEL_COST = 1;
+export const JUMPGATE_FUEL_COST = 0; // jumpgates cost credits only, no fuel
 export const JUMPGATE_TRAVEL_COST_CREDITS = 50; // credits to use a public jumpgate
 export const PLAYER_GATE_TRAVEL_COST_CREDITS = 25; // credits to use a player-built gate (cheaper)
 export const JUMPGATE_MIN_RANGE = 50;


### PR DESCRIPTION
## Summary
- FUEL_MIN_TANK: 1000 → 10000
- JUMPGATE_FUEL_COST: 1 → 0 (nur Credits)
- Hyperdrive Regen per Tier: MK.I=2, MK.II=4, MK.III=6, Void/MK.IV=8, MK.V=10
- Drive MK.IV: Range 256→384, Speed 6→8
- Drive MK.V: Range 512→768, Speed 10→12
- CHARGE Button → OVERPOWER
- Fuel-Balken immer sichtbar (nicht nur Stats-Tab), über Hyperdrive

Fixes #381