### PR TITLE
feat: add FABRIK cockpit program — ship module crafting

### DIFF
--- a/packages/client/src/components/GameScreen.tsx
+++ b/packages/client/src/components/GameScreen.tsx
@@ -19,6 +19,7 @@ import { CombatDialog } from './CombatDialog';
 import { BattleResultDialog } from './BattleResultDialog';
 import { AcepProgram } from './AcepProgram';
 import { FriendsScreen } from './FriendsScreen';
+import { FabrikPanel } from './FabrikPanel';
 import { HelpOverlay } from './HelpOverlay';
 import { AncientRuinDialog } from './AncientRuinDialog';
 import { CompendiumOverlay } from './CompendiumOverlay';
@@ -354,6 +355,8 @@ function renderScreen(monitorId: string) {
       return <AcepProgram />;
     case MONITORS.FRIENDS:
       return <FriendsScreen />;
+    case MONITORS.FABRIK:
+      return <FabrikPanel />;
     default:
       return <div style={{ padding: 12 }}>UNKNOWN MONITOR</div>;
   }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2018,6 +2018,7 @@ export const MONITORS = {
   NEWS: 'NEWS',
   ACEP: 'ACEP',
   FRIENDS: 'FRIENDS',
+  FABRIK: 'FABRIK',
 } as const;
 
 export type MonitorId = (typeof MONITORS)[keyof typeof MONITORS];
@@ -2037,6 +2038,7 @@ export const COCKPIT_PROGRAMS: MonitorId[] = [
   MONITORS.LOG,
   MONITORS.ACEP,
   MONITORS.FRIENDS,
+  MONITORS.FABRIK,
 ];
 
 /** Labels for cockpit program buttons */
@@ -2055,6 +2057,7 @@ export const COCKPIT_PROGRAM_LABELS: Record<string, string> = {
   MODULES: 'MODULES',
   ACEP: 'ACEP',
   FRIENDS: 'FRIENDS',
+  FABRIK: 'FABRIK',
 };
 
 // --- Phase 5: Deep Systems ---


### PR DESCRIPTION
## Summary
- Add `FABRIK` to MONITORS, COCKPIT_PROGRAMS, and COCKPIT_PROGRAM_LABELS
- Wire FabrikPanel component in GameScreen renderScreen()
- FabrikPanel was already fully implemented but never integrated into the UI

Players can now craft modules from blueprints/research via the FABRIK program in the cockpit.

## Test plan
- [ ] FABRIK button appears in program selector
- [ ] Clicking FABRIK shows FabrikPanel with blueprint list and cargo modules
- [ ] [HERSTELLEN] crafts module from blueprint
- [ ] [AKTIVIEREN] unlocks blueprint in tech tree
- [ ] [INSTALLIEREN] installs module on ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)