### PR TITLE
fix: #402 FABRIK bugs — inventory refresh, craft handler, slot index

### DIFF
--- a/packages/client/src/components/FabrikPanel.tsx
+++ b/packages/client/src/components/FabrikPanel.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
+import { MODULES, SPECIALIZED_SLOT_INDEX } from '@void-sector/shared';
 
 const green = '#00FF88';
 const dimGreen = 'rgba(0,255,136,0.3)';
@@ -94,7 +95,11 @@ export function FabrikPanel() {
               <button
                 style={{ ...btnStyle, opacity: installedIds.has(m.itemId) ? 0.4 : 1 }}
                 disabled={installedIds.has(m.itemId)}
-                onClick={() => network.sendInstallModule('', m.itemId, 0)}
+                onClick={() => {
+                  const modDef = MODULES[m.itemId];
+                  const slot = modDef ? (SPECIALIZED_SLOT_INDEX[modDef.category] ?? 0) : 0;
+                  network.sendInstallModule('', m.itemId, slot);
+                }}
               >
                 {installedIds.has(m.itemId) ? t('fabrik.installed') : t('fabrik.install')}
               </button>

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -1816,6 +1816,15 @@ class GameNetwork {
       room.send('getInventory');
     });
 
+    room.onMessage('craftResult', (data: { success: boolean; moduleId?: string; error?: string }) => {
+      const store = useStore.getState();
+      if (data.success) {
+        store.addLogEntry(`MODUL HERGESTELLT: ${data.moduleId ?? '?'}`);
+      } else {
+        store.addLogEntry(`HERSTELLUNG FEHLGESCHLAGEN: ${data.error ?? 'Unbekannter Fehler'}`);
+      }
+    });
+
     room.onMessage('stationProductionUpdate', (data: StationProductionState) => {
       useStore.getState().setStationProductionState(data);
     });
@@ -2574,8 +2583,8 @@ class GameNetwork {
     this.sectorRoom?.send('getInventory');
   }
 
-  sendCraftModule(blueprintId: string) {
-    this.sectorRoom?.send('craftModule', { blueprintId });
+  sendCraftModule(moduleId: string) {
+    this.sectorRoom?.send('craftModule', { moduleId });
   }
 
   // --- Station Production ---

--- a/packages/server/src/rooms/services/ShipService.ts
+++ b/packages/server/src/rooms/services/ShipService.ts
@@ -267,6 +267,10 @@ export class ShipService {
 
     client.send('craftResult', { success: true, moduleId: data.moduleId });
     client.send('logEntry', `HERGESTELLT: ${mod.name ?? data.moduleId}`);
+    // Refresh client inventory, cargo, and credits
+    client.send('inventoryUpdated', {});
+    client.send('cargoUpdate', await getCargoState(auth.userId));
+    client.send('creditsUpdate', { credits: await getPlayerCredits(auth.userId) });
     awardWissenAndNotify(client, auth.userId, 3);  // +3 per craft
   }
 
@@ -290,6 +294,8 @@ export class ShipService {
       unlockedModules: updated.unlockedModules,
       blueprints: updated.blueprints,
     });
+    // Refresh client inventory so FabrikPanel updates
+    client.send('inventoryUpdated', {});
     client.send(
       'logEntry',
       `BLAUPAUSE AKTIVIERT: ${MODULES[data.moduleId]?.name ?? data.moduleId}`,


### PR DESCRIPTION
## Summary
- **Bug 1**: `handleActivateBlueprint` now sends `inventoryUpdated` so FabrikPanel refreshes after blueprint consumption
- **Bug 2**: `handleCraftModule` now sends `inventoryUpdated` + `cargoUpdate` + `creditsUpdate` for full client sync
- **Bug 3**: Added `craftResult` client message handler with success/error log entries
- **Bug 4**: FabrikPanel uses `SPECIALIZED_SLOT_INDEX[category]` for correct slot instead of hardcoded `0`
- **Bug 5**: Fixed `sendCraftModule` param name `blueprintId` → `moduleId` to match server handler

Closes #402

## Test plan
- [ ] [AKTIVIEREN] removes blueprint from FABRIK list and CARGO
- [ ] [HERSTELLEN] deducts resources/credits and adds module to cargo
- [ ] [INSTALLIEREN] installs module in correct slot (not always generator)
- [ ] Error messages shown for insufficient resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)