### PR TITLE
fix: rulebook #388 — ACEP AUSBAU gating, wreck detection, legacy ship rename

### DIFF
--- a/packages/client/src/canvas/RadarRenderer.ts
+++ b/packages/client/src/canvas/RadarRenderer.ts
@@ -105,6 +105,8 @@ interface RadarState {
   /** Slow flight path from current position to target — drawn as dashed overlay */
   slowFlightPath?: Array<{ x: number; y: number }>;
   sectorWrecks?: Record<string, { tier: number; size: string }>;
+  /** ACEP EXPLORER effect: reveals Tier 4/5 wrecks without local scan */
+  wreckDetection?: boolean;
   constructionSites?: ConstructionSiteState[];
 }
 
@@ -577,12 +579,26 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
         const wkey = `${sx}:${sy}`;
         const wreck = state.sectorWrecks[wkey];
         if (wreck) {
+          // Tier 4/5 wrecks detected via ACEP wreckDetection get a brighter highlight
+          const isDetected = state.wreckDetection && wreck.tier >= 4;
           ctx.save();
           ctx.font = `${Math.floor(CELL_H * 0.55)}px 'Share Tech Mono', 'Courier New', monospace`;
-          ctx.fillStyle = 'rgba(255, 176, 0, 0.55)';
+          ctx.fillStyle = isDetected
+            ? 'rgba(255, 120, 0, 0.85)'
+            : 'rgba(255, 176, 0, 0.55)';
           ctx.textAlign = 'center';
           ctx.textBaseline = 'middle';
           ctx.fillText('⊠', cellX, cellY);
+          // Pulsing glow ring for ACEP-detected high-tier wrecks
+          if (isDetected) {
+            const t = state.animTime ?? 0;
+            const pulse = 0.4 + 0.4 * Math.sin(t / 500);
+            ctx.strokeStyle = `rgba(255, 120, 0, ${pulse})`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.arc(cellX, cellY, Math.floor(CELL_H * 0.35), 0, Math.PI * 2);
+            ctx.stroke();
+          }
           ctx.restore();
         }
       }

--- a/packages/client/src/components/RadarCanvas.tsx
+++ b/packages/client/src/components/RadarCanvas.tsx
@@ -83,6 +83,7 @@ export function RadarCanvas({ onSectorTap }: RadarCanvasProps = {}) {
       miningActive: !!state.mining?.active,
       civShips: state.civShips,
       sectorWrecks: state.sectorWrecks,
+      wreckDetection: state.ship?.acepEffects?.wreckDetection ?? false,
       constructionSites: state.constructionSites,
       slowFlightPath:
         state.slowFlightActive && state.autopilot?.active

--- a/packages/server/src/engine/__tests__/acepXpService.test.ts
+++ b/packages/server/src/engine/__tests__/acepXpService.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock DB + query dependencies so pure function imports work
+vi.mock('../../db/client.js', () => ({
+  query: vi.fn(),
+}));
+vi.mock('../../db/queries.js', () => ({
+  deductCredits: vi.fn(),
+  addCredits: vi.fn(),
+  deductWissen: vi.fn(),
+}));
+
+import { getAusbauGating } from '../acepXpService.js';
 
 /**
  * Unit tests for ACEP XP budget logic.
@@ -90,5 +102,33 @@ describe('ACEP XP budget logic', () => {
     // 50 ausbau, 45 kampf (5 remaining on path) — but total is 95, so 5 remaining on budget
     const current2 = { ausbau: 50, intel: 0, kampf: 45, explorer: 0 };
     expect(computeEffectiveGain(current2, 'kampf', 10)).toBe(5); // path cap limits
+  });
+});
+
+describe('getAusbauGating', () => {
+  it('0 XP: lab 1, no factory', () => {
+    const g = getAusbauGating(0);
+    expect(g.maxLabTier).toBe(1);
+    expect(g.factoryUnlocked).toBe(false);
+  });
+
+  it('10 XP: lab 2, factory unlocked', () => {
+    const g = getAusbauGating(10);
+    expect(g.maxLabTier).toBe(2);
+    expect(g.factoryUnlocked).toBe(true);
+  });
+
+  it('25 XP: lab 3', () => {
+    expect(getAusbauGating(25).maxLabTier).toBe(3);
+  });
+
+  it('40 XP: lab 4', () => {
+    expect(getAusbauGating(40).maxLabTier).toBe(4);
+  });
+
+  it('50 XP: lab 5, speed bonus 0.5', () => {
+    const g = getAusbauGating(50);
+    expect(g.maxLabTier).toBe(5);
+    expect(g.factorySpeedBonus).toBe(0.5);
   });
 });

--- a/packages/server/src/engine/acepXpService.ts
+++ b/packages/server/src/engine/acepXpService.ts
@@ -79,6 +79,26 @@ export function getAcepEffects(xp: AcepXpSummary): AcepEffects {
   };
 }
 
+/**
+ * AUSBAU gates: research lab max tier and factory access based on AUSBAU XP.
+ * - AUSBAU 0-9: Lab tier 1 only, no factory
+ * - AUSBAU 10-24: Lab tier 2, factory basic recipes
+ * - AUSBAU 25-39: Lab tier 3, factory advanced recipes
+ * - AUSBAU 40-49: Lab tier 4, factory all recipes
+ * - AUSBAU 50: Lab tier 5 (max), factory all recipes + speed bonus
+ */
+export function getAusbauGating(ausbauXp: number): {
+  maxLabTier: number;
+  factoryUnlocked: boolean;
+  factorySpeedBonus: number; // 0.0 to 0.5
+} {
+  if (ausbauXp >= 50) return { maxLabTier: 5, factoryUnlocked: true, factorySpeedBonus: 0.5 };
+  if (ausbauXp >= 40) return { maxLabTier: 4, factoryUnlocked: true, factorySpeedBonus: 0.3 };
+  if (ausbauXp >= 25) return { maxLabTier: 3, factoryUnlocked: true, factorySpeedBonus: 0.15 };
+  if (ausbauXp >= 10) return { maxLabTier: 2, factoryUnlocked: true, factorySpeedBonus: 0 };
+  return { maxLabTier: 1, factoryUnlocked: false, factorySpeedBonus: 0 };
+}
+
 const COL: Record<AcepPath, string> = {
   ausbau: 'acep_ausbau_xp',
   intel: 'acep_intel_xp',

--- a/packages/server/src/engine/permadeathService.ts
+++ b/packages/server/src/engine/permadeathService.ts
@@ -160,8 +160,8 @@ export async function destroyShipAndCreateLegacy(params: {
   );
   const oldGen = genResult.rows[0]?.acep_generation ?? 0;
 
-  // Create new legacy ship (named "Phoenix-<timestamp>")
-  const shipName = `Phoenix-${Date.now().toString(36).toUpperCase().slice(-4)}`;
+  // Create new legacy ship (named "Legacy-<timestamp>")
+  const shipName = `Legacy-${Date.now().toString(36).toUpperCase().slice(-4)}`;
   const { rows } = await query<{ id: string }>(
     `INSERT INTO ships
        (owner_id, name, fuel, active,

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -130,6 +130,7 @@ import {
   countJumpGateLinks,
   getResearchLabTier,
   upgradeResearchLabTier,
+  getActiveShip,
   logExpansionEvent,
 } from '../../db/queries.js';
 import {
@@ -146,7 +147,7 @@ import {
   playerKnowsQuadrant,
 } from '../../db/quadrantQueries.js';
 import { isInt, rejectGuest } from './utils.js';
-import { addAcepXpForPlayer } from '../../engine/acepXpService.js';
+import { addAcepXpForPlayer, getAcepXpSummary, getAusbauGating } from '../../engine/acepXpService.js';
 import {
   createConstructionSite,
   getConstructionSite,
@@ -503,6 +504,21 @@ export class WorldService {
     if (!result.valid) {
       client.send('error', { code: 'LAB_UPGRADE_FAIL', message: result.error! });
       return;
+    }
+
+    // AUSBAU gating: check ACEP XP before allowing lab upgrade
+    const targetTier = labTier + 1;
+    const activeShip = await getActiveShip(auth.userId);
+    if (activeShip) {
+      const acepXp = await getAcepXpSummary(activeShip.id);
+      const gating = getAusbauGating(acepXp.ausbau);
+      if (targetTier > gating.maxLabTier) {
+        client.send('error', {
+          code: 'AUSBAU_REQUIRED',
+          message: `AUSBAU Level zu niedrig. Benötigt: ${targetTier * 10} AUSBAU XP.`,
+        });
+        return;
+      }
     }
 
     // Deduct costs


### PR DESCRIPTION
## Summary
- Phoenix -> Legacy Ship-Naming bei Permadeath
- getAusbauGating(): Lab-Tier + Fabrik durch AUSBAU XP gegated (0/10/25/40/50)
- Lab-Upgrade prueft AUSBAU-Level vor Freigabe
- Wreck Detection: Tier 4/5 Wracks auf Radar sichtbar wenn Explorer >= 25 XP
- Pulsierender Glow-Ring fuer ACEP-detektierte High-Tier Wracks
- 5 neue Tests fuer getAusbauGating

Fixes #388