### PR TITLE
fix: rulebook #390 — remove natural jumpgates, relay ranges, lab upgrades; progress-colored construction sites

### DIFF
--- a/packages/client/src/canvas/RadarRenderer.ts
+++ b/packages/client/src/canvas/RadarRenderer.ts
@@ -293,13 +293,17 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
         }
       }
 
-      // Construction site marker: cyan pulsing ⚙ dot for sectors with an active construction site
+      // Construction site marker: progress-colored ⚙
       if (state.constructionSites && !isPlayer) {
-        const hasSite = state.constructionSites.some((c) => c.sectorX === sx && c.sectorY === sy);
-        if (hasSite) {
+        const site = state.constructionSites.find((c) => c.sectorX === sx && c.sectorY === sy);
+        if (site) {
+          const progress = site.progress ?? 0; // 0-100
           const t = state.animTime ?? 0;
-          const alpha = 0.5 + 0.5 * Math.sin(t / 800);
-          ctx.fillStyle = `rgba(0,255,200,${alpha})`;
+          const pulse = 0.7 + 0.3 * Math.sin(t / 800);
+          // Color transitions from red (0%) through orange (50%) to green (100%)
+          const r = progress < 50 ? 255 : Math.round(255 - (progress - 50) * 5.1);
+          const g = progress < 50 ? Math.round(progress * 5.1) : 255;
+          ctx.fillStyle = `rgba(${r},${g},0,${pulse})`;
           ctx.font = `${coordSize}px 'Share Tech Mono', monospace`;
           ctx.textAlign = 'right';
           ctx.textBaseline = 'top';

--- a/packages/server/src/__tests__/jumpgateQueries.test.ts
+++ b/packages/server/src/__tests__/jumpgateQueries.test.ts
@@ -25,11 +25,15 @@ describe('jumpgate constants', () => {
   it('max chain hops is 10', () => {
     expect(JUMPGATE_MAX_CHAIN_HOPS).toBe(10);
   });
+
+  it('JUMPGATE_CHANCE is 0 (natural jumpgates disabled)', () => {
+    expect(JUMPGATE_CHANCE).toBe(0);
+  });
 });
 
 describe('ancient jumpgate spawn rate', () => {
-  it('ancient gates are much rarer than normal gates', () => {
-    expect(ANCIENT_JUMPGATE_SPAWN_RATE).toBeLessThan(JUMPGATE_CHANCE * 0.1);
+  it('ancient gates have a very low spawn rate', () => {
+    expect(ANCIENT_JUMPGATE_SPAWN_RATE).toBeLessThan(0.001);
   });
 
   it('ancient gate min range exceeds normal max range', () => {
@@ -62,13 +66,11 @@ describe('ancient jumpgate spawn rate', () => {
     }
   });
 
-  it('normal checkJumpGate is unaffected by ancient gate changes', () => {
+  it('checkJumpGate always returns false (natural jumpgates disabled)', () => {
     let normalCount = 0;
     for (let x = 0; x < 1000; x++) {
       if (checkJumpGate(x, 42)) normalCount++;
     }
-    // JUMPGATE_CHANCE = 0.005, expect far fewer than 100 in 1000
-    expect(normalCount).toBeGreaterThan(0);
-    expect(normalCount).toBeLessThan(100);
+    expect(normalCount).toBe(0);
   });
 });

--- a/packages/server/src/engine/__tests__/jumpgates.test.ts
+++ b/packages/server/src/engine/__tests__/jumpgates.test.ts
@@ -7,10 +7,10 @@ import {
 } from '../jumpgates.js';
 
 describe('JumpGate Generation', () => {
-  it('should deterministically detect gates', () => {
-    const result1 = checkJumpGate(100, 200);
-    const result2 = checkJumpGate(100, 200);
-    expect(result1).toBe(result2);
+  it('checkJumpGate always returns false (natural jumpgates disabled)', () => {
+    expect(checkJumpGate(100, 200)).toBe(false);
+    expect(checkJumpGate(0, 0)).toBe(false);
+    expect(checkJumpGate(9999, 9999)).toBe(false);
   });
 
   it('should generate targets within range', () => {
@@ -22,14 +22,12 @@ describe('JumpGate Generation', () => {
     expect(dist).toBeLessThanOrEqual(10002); // slight rounding tolerance
   });
 
-  it('should respect JUMPGATE_CHANCE probability (~0.5%)', () => {
+  it('should return false for all sectors (natural jumpgates disabled)', () => {
     let count = 0;
-    for (let i = 0; i < 50000; i++) {
+    for (let i = 0; i < 1000; i++) {
       if (checkJumpGate(i * 3 + 1, i * 7 + 2)) count++;
     }
-    const rate = count / 50000;
-    expect(rate).toBeGreaterThan(0.001);
-    expect(rate).toBeLessThan(0.015);
+    expect(count).toBe(0);
   });
 
   it('should convert angles to compass directions', () => {

--- a/packages/server/src/engine/__tests__/structures.test.ts
+++ b/packages/server/src/engine/__tests__/structures.test.ts
@@ -1,57 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { validateBuild, validateLabUpgrade } from '../commands.js';
+import { validateBuild } from '../commands.js';
 import type { CargoState } from '@void-sector/shared';
 import { createAPState } from '../ap.js';
-
-const fullCargo = {
-  ore: 999,
-  gas: 999,
-  crystal: 999,
-  artefact: 0,
-  slates: 0,
-  artefact_drive: 0,
-  artefact_cargo: 0,
-  artefact_scanner: 0,
-  artefact_armor: 0,
-  artefact_weapon: 0,
-  artefact_shield: 0,
-  artefact_defense: 0,
-  artefact_special: 0,
-  artefact_mining: 0,
-};
-
-describe('validateLabUpgrade', () => {
-  it('fails if no existing lab (tier 0)', () => {
-    const r = validateLabUpgrade(0, 9999, fullCargo);
-    expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/no.*lab/i);
-  });
-
-  it('fails if already at max tier (5)', () => {
-    const r = validateLabUpgrade(5, 9999, fullCargo);
-    expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/max/i);
-  });
-
-  it('fails if insufficient credits', () => {
-    const r = validateLabUpgrade(1, 0, fullCargo);
-    expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/credits/i);
-  });
-
-  it('fails if insufficient ore', () => {
-    const r = validateLabUpgrade(1, 9999, { ...fullCargo, ore: 0 });
-    expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/ore/i);
-  });
-
-  it('succeeds for valid upgrade from tier 1 to 2', () => {
-    const r = validateLabUpgrade(1, 9999, fullCargo);
-    expect(r.valid).toBe(true);
-    expect(r.targetTier).toBe(2);
-    expect(r.costs).toBeDefined();
-  });
-});
 
 describe('validateBuild', () => {
   it('succeeds with sufficient cargo and AP for comm_relay', () => {

--- a/packages/server/src/engine/commands.ts
+++ b/packages/server/src/engine/commands.ts
@@ -36,8 +36,6 @@ import {
   PIRATE_DAMAGE_PER_LEVEL,
   MAX_ACTIVE_QUESTS,
   XP_LEVELS,
-  RESEARCH_LAB_UPGRADE_COSTS,
-  RESEARCH_LAB_MAX_TIER,
 } from '@void-sector/shared';
 import { spendAP } from './ap.js';
 import { startMining, createMiningState } from './mining.js';
@@ -535,35 +533,3 @@ export function getReputationTier(reputation: number): string {
   return 'honored';
 }
 
-// --- Research Lab Upgrade Validation ---
-
-export function validateLabUpgrade(
-  currentLabTier: number,
-  credits: number,
-  cargo: { ore: number; crystal: number },
-): {
-  valid: boolean;
-  error?: string;
-  targetTier?: number;
-  costs?: { credits: number; ore: number; crystal: number };
-} {
-  if (currentLabTier <= 0) return { valid: false, error: 'No research lab to upgrade' };
-  if (currentLabTier >= RESEARCH_LAB_MAX_TIER)
-    return { valid: false, error: 'Lab already at max tier' };
-
-  const targetTier = currentLabTier + 1;
-  const costs = RESEARCH_LAB_UPGRADE_COSTS[targetTier];
-  if (!costs) return { valid: false, error: 'Unknown upgrade tier' };
-
-  if (credits < costs.credits) {
-    return { valid: false, error: `Insufficient credits (need ${costs.credits})` };
-  }
-  if (cargo.ore < costs.ore) {
-    return { valid: false, error: `Insufficient ore (need ${costs.ore})` };
-  }
-  if (cargo.crystal < costs.crystal) {
-    return { valid: false, error: `Insufficient crystal (need ${costs.crystal})` };
-  }
-
-  return { valid: true, targetTier, costs };
-}

--- a/packages/server/src/engine/gameConfigApply.ts
+++ b/packages/server/src/engine/gameConfigApply.ts
@@ -28,7 +28,6 @@ import {
   JUMPGATE_CONNECTION_LIMITS,
   JUMPGATE_BUILD_COST,
   JUMPGATE_UPGRADE_COSTS,
-  RESEARCH_LAB_UPGRADE_COSTS,
   STRUCTURE_COSTS,
   STRUCTURE_AP_COSTS,
   STORAGE_TIERS,
@@ -170,10 +169,6 @@ export function applyConfigValue(key: string, value: any): void {
   }
   if (key === 'JUMPGATE_UPGRADE_COSTS') {
     deepAssign(JUMPGATE_UPGRADE_COSTS, value);
-    return;
-  }
-  if (key === 'RESEARCH_LAB_UPGRADE_COSTS') {
-    deepAssign(RESEARCH_LAB_UPGRADE_COSTS, value);
     return;
   }
   if (key === 'STRUCTURE_COSTS') {

--- a/packages/server/src/engine/gameConfigSeed.ts
+++ b/packages/server/src/engine/gameConfigSeed.ts
@@ -118,7 +118,6 @@ import {
   STRUCTURE_AP_COSTS,
   JUMPGATE_BUILD_COST,
   JUMPGATE_UPGRADE_COSTS,
-  RESEARCH_LAB_UPGRADE_COSTS,
   MAX_ACTIVE_QUESTS,
   QUEST_EXPIRY_DAYS,
   SCAN_EVENT_CHANCE,
@@ -156,7 +155,6 @@ import {
   BASE_COMM_RANGE,
   BASE_SCANNER_LEVEL,
   LAB_WISSEN_MULTIPLIER,
-  RESEARCH_LAB_MAX_TIER,
   RESEARCH_TICK_MS,
   WRECK_BASE_DIFFICULTY,
   WRECK_SALVAGE_DURATION_MS,
@@ -339,7 +337,6 @@ const STATIC_SEED: ConfigSeedEntry[] = [
   { key: 'STRUCTURE_AP_COSTS', category: 'structures', description: 'AP costs to build structures', getDefault: () => STRUCTURE_AP_COSTS },
   { key: 'JUMPGATE_BUILD_COST', category: 'structures', description: 'Cost to build player jumpgate', getDefault: () => JUMPGATE_BUILD_COST },
   { key: 'JUMPGATE_UPGRADE_COSTS', category: 'structures', description: 'Jumpgate upgrade costs by type', getDefault: () => JUMPGATE_UPGRADE_COSTS },
-  { key: 'RESEARCH_LAB_UPGRADE_COSTS', category: 'structures', description: 'Research lab upgrade costs per tier', getDefault: () => RESEARCH_LAB_UPGRADE_COSTS },
 
   // ══════════════════════════════════════════════════════════════════════════════
   // Quests
@@ -401,7 +398,6 @@ const STATIC_SEED: ConfigSeedEntry[] = [
   // Research
   // ══════════════════════════════════════════════════════════════════════════════
   { key: 'LAB_WISSEN_MULTIPLIER', category: 'research', description: 'Lab tier Wissen generation multiplier', getDefault: () => LAB_WISSEN_MULTIPLIER },
-  { key: 'RESEARCH_LAB_MAX_TIER', category: 'research', description: 'Maximum research lab tier', getDefault: () => RESEARCH_LAB_MAX_TIER },
   { key: 'RESEARCH_TICK_MS', category: 'research', description: 'Research tick interval in milliseconds', getDefault: () => RESEARCH_TICK_MS },
 
   // ══════════════════════════════════════════════════════════════════════════════

--- a/packages/server/src/engine/jumpgates.ts
+++ b/packages/server/src/engine/jumpgates.ts
@@ -2,7 +2,6 @@ import { hashCoords } from './worldgen.js';
 import {
   WORLD_SEED,
   JUMPGATE_SALT,
-  JUMPGATE_CHANCE,
   JUMPGATE_MIN_RANGE,
   JUMPGATE_MAX_RANGE,
   JUMPGATE_CODE_CHANCE,
@@ -15,9 +14,8 @@ import {
 } from '@void-sector/shared';
 import type { JumpGateType } from '@void-sector/shared';
 
-export function checkJumpGate(sectorX: number, sectorY: number): boolean {
-  const hash = hashCoords(sectorX, sectorY, WORLD_SEED + JUMPGATE_SALT);
-  return ((hash >>> 0) % 10000) / 10000 < JUMPGATE_CHANCE;
+export function checkJumpGate(_x: number, _y: number): boolean {
+  return false; // natural jumpgates disabled — only ancient gates spawn
 }
 
 export function checkAncientJumpGate(sectorX: number, sectorY: number): boolean {

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -810,7 +810,6 @@ export class SectorRoom extends Room<SectorRoomState> {
     this.onMessage('depositConstruction', async (client, data: DepositConstructionMessage) => {
       await this.world.handleDepositConstruction(client, data);
     });
-    this.onMessage('upgradeResearchLab', (client) => this.world.handleUpgradeResearchLab(client));
     this.onMessage('createSlate', async (client, data: CreateSlateMessage) => {
       await this.world.handleCreateSlate(client, data);
     });

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -28,7 +28,6 @@ import {
   validateBuild,
   validateCreateSlate,
   validateNpcBuyback,
-  validateLabUpgrade,
 } from '../../engine/commands.js';
 import {
   checkDistressCall,
@@ -128,8 +127,6 @@ import {
   insertJumpGateLink,
   removeJumpGateLink,
   countJumpGateLinks,
-  getResearchLabTier,
-  upgradeResearchLabTier,
   getActiveShip,
   logExpansionEvent,
 } from '../../db/queries.js';
@@ -147,7 +144,7 @@ import {
   playerKnowsQuadrant,
 } from '../../db/quadrantQueries.js';
 import { isInt, rejectGuest } from './utils.js';
-import { addAcepXpForPlayer, getAcepXpSummary, getAusbauGating } from '../../engine/acepXpService.js';
+import { addAcepXpForPlayer } from '../../engine/acepXpService.js';
 import {
   createConstructionSite,
   getConstructionSite,
@@ -478,67 +475,6 @@ export class WorldService {
     const updatedCargo = await getCargoState(auth.userId);
     client.send('cargoUpdate', updatedCargo);
     client.send('depositResult', { success: true });
-  }
-
-  // ── Research Lab Upgrade ────────────────────────────────────────────
-
-  async handleUpgradeResearchLab(client: Client): Promise<void> {
-    if (rejectGuest(client, 'Labor-Upgrade')) return;
-    if (!this.ctx.checkRate(client.sessionId, 'upgradeResearchLab', 3000)) {
-      client.send('error', { code: 'RATE_LIMIT', message: 'Too fast' });
-      return;
-    }
-
-    const auth = client.auth as AuthPayload;
-    const sx = this.ctx._px(client.sessionId);
-    const sy = this.ctx._py(client.sessionId);
-
-    const [labTier, cargo, credits] = await Promise.all([
-      getResearchLabTier(auth.userId),
-      getCargoState(auth.userId),
-      getPlayerCredits(auth.userId),
-    ]);
-
-    const result = validateLabUpgrade(labTier, credits, cargo);
-
-    if (!result.valid) {
-      client.send('error', { code: 'LAB_UPGRADE_FAIL', message: result.error! });
-      return;
-    }
-
-    // AUSBAU gating: check ACEP XP before allowing lab upgrade
-    const targetTier = labTier + 1;
-    const activeShip = await getActiveShip(auth.userId);
-    if (activeShip) {
-      const acepXp = await getAcepXpSummary(activeShip.id);
-      const gating = getAusbauGating(acepXp.ausbau);
-      if (targetTier > gating.maxLabTier) {
-        client.send('error', {
-          code: 'AUSBAU_REQUIRED',
-          message: `AUSBAU Level zu niedrig. Benötigt: ${targetTier * 10} AUSBAU XP.`,
-        });
-        return;
-      }
-    }
-
-    // Deduct costs
-    await deductCredits(auth.userId, result.costs!.credits);
-    await removeFromInventory(auth.userId, 'resource', 'ore', result.costs!.ore);
-    await removeFromInventory(auth.userId, 'resource', 'crystal', result.costs!.crystal);
-
-    // Upgrade the lab at player's current position
-    const newTier = await upgradeResearchLabTier(auth.userId, sx, sy);
-    if (!newTier) {
-      client.send('error', {
-        code: 'LAB_UPGRADE_FAIL',
-        message: 'No research lab at your location',
-      });
-      return;
-    }
-
-    client.send('labUpgradeResult', { success: true, newTier });
-    const updatedCargo = await getCargoState(auth.userId);
-    client.send('cargoUpdate', updatedCargo);
   }
 
   // ── Jumpgate Build ─────────────────────────────────────────────────

--- a/packages/shared/src/__tests__/constants.test.ts
+++ b/packages/shared/src/__tests__/constants.test.ts
@@ -7,7 +7,6 @@ import {
   AP_DEFAULTS,
   STRUCTURE_COSTS,
   STRUCTURE_AP_COSTS,
-  RELAY_RANGES,
   PRODUCTION_RECIPES,
   getAcepDominantPath,
   getAcepRadarPattern,
@@ -51,12 +50,6 @@ describe('constants', () => {
     expect(STRUCTURE_AP_COSTS.factory).toBe(20);
     expect(STRUCTURE_AP_COSTS.research_lab).toBe(25);
     expect(STRUCTURE_AP_COSTS.kontor).toBe(15);
-  });
-
-  it('RELAY_RANGES includes factory, research_lab, and kontor', () => {
-    expect(RELAY_RANGES.factory).toBe(0);
-    expect(RELAY_RANGES.research_lab).toBe(0);
-    expect(RELAY_RANGES.kontor).toBe(0);
   });
 
   it('PRODUCTION_RECIPES has valid recipes', () => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -108,34 +108,6 @@ export const LAB_WISSEN_MULTIPLIER: Record<number, number> = {
   5: 5.0,
 };
 
-/** Maximum research lab tier */
-export const RESEARCH_LAB_MAX_TIER = 5;
-
-/** Credits + material cost to upgrade research lab to the given tier */
-export const RESEARCH_LAB_UPGRADE_COSTS: Record<
-  number,
-  { credits: number; ore: number; crystal: number }
-> = {
-  2: { credits: 500, ore: 30, crystal: 20 },
-  3: { credits: 1200, ore: 60, crystal: 40 },
-  4: { credits: 2500, ore: 100, crystal: 80 },
-  5: { credits: 5000, ore: 150, crystal: 120 },
-};
-
-export const RELAY_RANGES: Record<StructureType, number> = {
-  comm_relay: 500,
-  mining_station: 500,
-  base: 1000,
-  storage: 0,
-  trading_post: 0,
-  defense_turret: 0,
-  station_shield: 0,
-  ion_cannon: 0,
-  factory: 0,
-  research_lab: 0,
-  kontor: 0,
-  jumpgate: 0,
-};
 
 // Player Jumpgate costs
 export const JUMPGATE_BUILD_COST = { credits: 500, crystal: 20, artefact: 5 };
@@ -2136,7 +2108,7 @@ export const FACTION_UPGRADE_TIERS: Record<
 };
 
 // JumpGates
-export const JUMPGATE_CHANCE = 0.005; // natural bidirectional/wormhole gates (1 in 200 sectors)
+export const JUMPGATE_CHANCE = 0; // disabled — only ancient jumpgates remain
 export const JUMPGATE_SALT = 777;
 export const JUMPGATE_FUEL_COST = 0; // jumpgates cost credits only, no fuel
 export const JUMPGATE_TRAVEL_COST_CREDITS = 50; // credits to use a public jumpgate


### PR DESCRIPTION
## Summary
- JUMPGATE_CHANCE: 0 (nur noch Ancient Jumpgates)
- checkJumpGate() immer false
- RELAY_RANGES geloescht (toter Code)
- Lab-Upgrade-System komplett entfernt (AUSBAU-Gating aus #388 ersetzt es)
- Baustellen-Radar: Fortschrittsfarbe rot->orange->gruen statt statisch cyan

Fixes #390