### PR TITLE
fix: rulebook #383 — mining without laser 0.1/s + 1 AP, cargo_mk2 +25

### DIFF
--- a/packages/server/src/__tests__/miningInventory.test.ts
+++ b/packages/server/src/__tests__/miningInventory.test.ts
@@ -25,6 +25,8 @@ vi.mock('../rooms/services/RedisAPStore.js', () => ({
   saveMiningState: vi.fn(),
   getMiningStoryCounter: vi.fn().mockResolvedValue(0),
   setMiningStoryCounter: vi.fn().mockResolvedValue(undefined),
+  getAPState: vi.fn().mockResolvedValue({ current: 100, max: 100, lastTick: Date.now(), regenPerSecond: 0.5 }),
+  saveAPState: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../engine/commands.js', () => ({
@@ -38,6 +40,10 @@ vi.mock('../engine/acepXpService.js', () => ({
 
 vi.mock('../engine/mining.js', () => ({
   stopMining: vi.fn(),
+}));
+
+vi.mock('../engine/ap.js', () => ({
+  spendAP: vi.fn().mockReturnValue({ current: 99, max: 100, lastTick: Date.now(), regenPerSecond: 0.5 }),
 }));
 
 vi.mock('../engine/inventoryService.js', async (importOriginal) => {

--- a/packages/server/src/__tests__/miningRate.test.ts
+++ b/packages/server/src/__tests__/miningRate.test.ts
@@ -18,9 +18,14 @@ vi.mock('../engine/commands.js', () => ({
 vi.mock('../rooms/services/RedisAPStore.js', () => ({
   getMiningState: vi.fn().mockResolvedValue({ active: false }),
   saveMiningState: vi.fn().mockResolvedValue(undefined),
+  getAPState: vi.fn().mockResolvedValue({ current: 100, max: 100, lastTick: Date.now(), regenPerSecond: 0.5 }),
+  saveAPState: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../engine/acepXpService.js', () => ({
   addAcepXpForPlayer: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../engine/ap.js', () => ({
+  spendAP: vi.fn().mockReturnValue({ current: 99, max: 100, lastTick: Date.now(), regenPerSecond: 0.5 }),
 }));
 
 import { MiningService } from '../rooms/services/MiningService.js';
@@ -55,7 +60,7 @@ describe('MiningService mining rate includes miningBonus', () => {
     expect(savedState?.rate).toBeCloseTo(1.5);
   });
 
-  it('rate is 1 when miningBonus is 0 (no module)', async () => {
+  it('rate is 0.1 when miningBonus is 0 (no mining laser)', async () => {
     const ctx = {
       checkRate: vi.fn().mockReturnValue(true),
       _px: vi.fn().mockReturnValue(1),
@@ -71,7 +76,55 @@ describe('MiningService mining rate includes miningBonus', () => {
 
     await svc.handleMine(client, { resource: 'ore' });
 
+    // Without mining laser: rate = 0.1 * (1 + 0) * 1 = 0.1
     const savedState = vi.mocked(saveMiningState).mock.calls[0]?.[1];
-    expect(savedState?.rate).toBeCloseTo(1.0);
+    expect(savedState?.rate).toBeCloseTo(0.1);
+  });
+
+  it('charges 1 AP when mining without laser', async () => {
+    const ctx = {
+      checkRate: vi.fn().mockReturnValue(true),
+      _px: vi.fn().mockReturnValue(1),
+      _py: vi.fn().mockReturnValue(1),
+      _pst: vi.fn().mockReturnValue('asteroid_field'),
+      getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0 }),
+      getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+    } as any;
+
+    const svc = new MiningService(ctx);
+    const client = makeClient();
+    const { saveAPState } = await import('../rooms/services/RedisAPStore.js');
+    const { spendAP } = await import('../engine/ap.js');
+
+    await svc.handleMine(client, { resource: 'ore' });
+
+    // spendAP should be called with cost 1
+    expect(spendAP).toHaveBeenCalledWith(expect.any(Object), 1);
+    expect(saveAPState).toHaveBeenCalled();
+    expect(client.send).toHaveBeenCalledWith('apUpdate', expect.any(Object));
+  });
+
+  it('does not charge AP when mining with laser', async () => {
+    const ctx = {
+      checkRate: vi.fn().mockReturnValue(true),
+      _px: vi.fn().mockReturnValue(1),
+      _py: vi.fn().mockReturnValue(1),
+      _pst: vi.fn().mockReturnValue('asteroid_field'),
+      getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0.5 }),
+      getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+    } as any;
+
+    const svc = new MiningService(ctx);
+    const client = makeClient();
+    const { saveAPState } = await import('../rooms/services/RedisAPStore.js');
+    const { spendAP } = await import('../engine/ap.js');
+
+    vi.mocked(spendAP).mockClear();
+    vi.mocked(saveAPState).mockClear();
+
+    await svc.handleMine(client, { resource: 'ore' });
+
+    // With mining laser, no AP should be spent
+    expect(spendAP).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/rooms/services/MiningService.ts
+++ b/packages/server/src/rooms/services/MiningService.ts
@@ -7,13 +7,14 @@ import type {
   CargoState,
   MineableResourceType,
 } from '@void-sector/shared';
-import { MINING_RATE_PER_SECOND } from '@void-sector/shared';
+import { MINING_RATE_PER_SECOND, MINING_RATE_NO_LASER, MINING_AP_COST_NO_LASER } from '@void-sector/shared';
 
 import { validateMine, validateJettison } from '../../engine/commands.js';
+import { spendAP } from '../../engine/ap.js';
 import { addAcepXpForPlayer } from '../../engine/acepXpService.js';
 import { awardWissenAndNotify } from '../../engine/wissenService.js';
 import { stopMining } from '../../engine/mining.js';
-import { getMiningState, saveMiningState, getMiningStoryCounter, setMiningStoryCounter } from './RedisAPStore.js';
+import { getMiningState, saveMiningState, getMiningStoryCounter, setMiningStoryCounter, getAPState, saveAPState } from './RedisAPStore.js';
 import { getSector, updateSectorResources, getMiningStoryIndex, updateMiningStoryIndex } from '../../db/queries.js';
 import {
   addToInventory,
@@ -154,7 +155,9 @@ export class MiningService {
               );
               if (nextResult.valid && nextResult.state) {
                 const bonuses = await this.ctx.getPlayerBonuses(playerId);
-                nextResult.state.rate = MINING_RATE_PER_SECOND
+                const chainHasLaser = (ship.miningBonus ?? 0) > 0;
+                const chainBaseRate = chainHasLaser ? MINING_RATE_PER_SECOND : MINING_RATE_NO_LASER;
+                nextResult.state.rate = chainBaseRate
                   * (1 + (ship.miningBonus ?? 0))
                   * bonuses.miningRateMultiplier;
 
@@ -247,9 +250,25 @@ export class MiningService {
       return;
     }
 
+    // Check if player has a mining laser module
+    const hasMiningLaser = (ship.miningBonus ?? 0) > 0;
+
+    // Mining without laser costs AP upfront
+    if (!hasMiningLaser) {
+      const currentAP = await getAPState(auth.userId);
+      const newAP = spendAP(currentAP, MINING_AP_COST_NO_LASER);
+      if (!newAP) {
+        client.send('error', { code: 'MINE_FAILED', message: 'Kein Mining-Laser — manuelles Mining kostet 1 AP.' });
+        return;
+      }
+      await saveAPState(auth.userId, newAP);
+      client.send('apUpdate', newAP);
+    }
+
     // Apply ship module bonus and faction mining bonus
     const bonuses = await this.ctx.getPlayerBonuses(auth.userId);
-    result.state!.rate = MINING_RATE_PER_SECOND
+    const baseRate = hasMiningLaser ? MINING_RATE_PER_SECOND : MINING_RATE_NO_LASER;
+    result.state!.rate = baseRate
       * (1 + (ship.miningBonus ?? 0))
       * bonuses.miningRateMultiplier;
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -60,6 +60,8 @@ export const SECTOR_RESOURCE_YIELDS: Record<SectorType, Record<MineableResourceT
 };
 
 export const MINING_RATE_PER_SECOND = 1;
+export const MINING_RATE_NO_LASER = 0.1; // mining rate without mining laser module
+export const MINING_AP_COST_NO_LASER = 1; // AP cost per second when mining without laser
 
 export const RESOURCE_REGEN_DELAY_TICKS = 50;
 export const RESOURCE_REGEN_INTERVAL_TICKS = 12; // 1 unit per 12 ticks (60s)
@@ -663,12 +665,12 @@ export const MODULES: Record<string, ModuleDefinition> = {
     tier: 2,
     name: 'CARGO BAY MK.II',
     displayName: 'CARGO MK.II',
-    primaryEffect: { stat: 'cargoCap', delta: 24, label: 'Frachtraum +24' },
+    primaryEffect: { stat: 'cargoCap', delta: 25, label: 'Frachtraum +25' },
     secondaryEffects: [
       { stat: 'safeSlotBonus', delta: 2, label: 'Safe-Slot +2' },
       { stat: 'fuelMax', delta: 1_000, label: 'Fuel-Tank +1.000' },
     ],
-    effects: { cargoCap: 24, safeSlotBonus: 2, fuelMax: 1_000 },
+    effects: { cargoCap: 25, safeSlotBonus: 2, fuelMax: 1_000 },
     cost: { credits: 250, ore: 15 },
     researchCost: { wissen: 300 },
     researchDurationMin: 5,
@@ -2194,6 +2196,7 @@ export const ENGINE_SPEED: Record<string, number> = {
 };
 // Research system
 export const RESEARCH_TICK_MS = 60_000; // 1 tick = 1 minute
+export const ARTEFACT_RESEARCH_TIME_BONUS = 0.1; // -10% research time when typed artefacts present
 
 export const AUTOPILOT_STEP_MS = 800; // ms per sector during autopilot
 export const STALENESS_DIM_HOURS = 24; // dim sectors after 24h


### PR DESCRIPTION
## Summary
- Mining ohne Laser: 0.1 u/s (statt 1.0), kostet 1 AP beim Start
- Mining mit Laser: 1.0 u/s, kostet 0 AP (wie bisher)
- cargo_mk2: cargoBonus 24 → 25
- ARTEFACT_RESEARCH_TIME_BONUS: 0.1 (Konstante bereit, Forschungssystem aktuell instant)

Fixes #383