### PR TITLE
fix: rulebook #384 — sell price ratio 0.6 → 0.8

### DIFF
--- a/packages/server/src/engine/dynamicPriceService.ts
+++ b/packages/server/src/engine/dynamicPriceService.ts
@@ -53,7 +53,7 @@ export function getDynamicSellPrice(
   reputationModifier: number = 0,
 ): number {
   const buyPrice = getDynamicPrice(resource, sectorX, sectorY, environment, reputationModifier);
-  return Math.round(buyPrice * 0.6);
+  return Math.round(buyPrice * 0.8);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Verkaufspreis-Ratio: 0.6 → 0.8 (dynamicPriceService)
- Start-Fuellstand 50-80%: bereits korrekt implementiert (npcStationEngine.ts:111)

Follow-Up Issues noetig fuer:
- Station-Economy Redesign: Rohstoff-Verbrauch → Produktion (Fuel/Ammo/Repair)
- Kontor-Anbindung an Lagerbestand
- Station-Level durch Handel

Fixes #384