### PR TITLE
fix: rulebook #382 — area scan shared with all players, remove dead RADAR_RADIUS

### DIFF
--- a/packages/server/src/rooms/services/ScanService.ts
+++ b/packages/server/src/rooms/services/ScanService.ts
@@ -25,8 +25,6 @@ import {
   getPlayerCredits,
   addCredits,
   getPlayerReputation,
-  getPlayerFaction,
-  getFactionMembersByPlayerIds,
   hasScannedRuin,
   insertAncientRuinScan,
   getActiveShip,
@@ -327,22 +325,15 @@ export class ScanService {
 
     client.send('scanResult', { sectors: foggedSectors, apRemaining: scanResult.newAP!.current });
 
-    // #159: Share scan results with online faction members
+    // Share area scan results with all players in the room
     try {
-      const playerFaction = await getPlayerFaction(auth.userId);
-      if (playerFaction) {
-        const memberIds = await getFactionMembersByPlayerIds(playerFaction.id);
-        for (const memberId of memberIds) {
-          if (memberId === auth.userId) continue;
-          this.ctx.sendToPlayer(memberId, 'scanResult', {
-            sectors: foggedSectors,
-            apRemaining: 0,
-            sharedByScan: true,
-          });
-        }
-      }
+      this.ctx.broadcast('scanResult', {
+        sectors: foggedSectors,
+        apRemaining: 0,
+        sharedByScan: true,
+      }, { except: client });
     } catch {
-      // Faction sharing failure must not break scan
+      // Scan sharing failure must not break scan
     }
 
     // Phase 4: Post-scan side effects — must not propagate errors (scanResult already sent)

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -46,8 +46,6 @@ export const AP_COSTS_LOCAL_SCAN = 1;
 
 export const WORLD_SEED = 77;
 
-export const RADAR_RADIUS = 3; // visible sectors around player on scan
-
 export const RECONNECTION_TIMEOUT_S = 15;
 
 export const SECTOR_RESOURCE_YIELDS: Record<SectorType, Record<MineableResourceType, number>> = {


### PR DESCRIPTION
## Summary
- Area-Scan Ergebnisse an ALLE Spieler im selben Room broadcasten (war nur Fraktion)
- Local Scans bleiben privat (nicht geteilt)
- Toter Code RADAR_RADIUS entfernt

Staleness-System (24h dim, 7d fade) behalten — ist ein gutes Feature fuer veraltete Entdeckungen.

Fixes #382