### PR TITLE
feat: #403 station VERWALTUNG panel — upgrade station/factory/cargo

### DIFF
--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -20,6 +20,7 @@ import {
 import type { ChatChannel, ConstructionSiteState, DataSlate } from '@void-sector/shared';
 import { JumpGatePanel } from './JumpGatePanel';
 import { PlayerGatePanel } from './PlayerGatePanel';
+import { StationManagePanel } from './StationManagePanel';
 import { InlineError } from './InlineError';
 
 type DrillDown =
@@ -278,6 +279,8 @@ export function DetailPanel() {
   const fuel = useStore((s) => s.fuel);
   const jumpGateInfo = useStore((s) => s.jumpGateInfo);
   const playerGateInfo = useStore((s) => s.playerGateInfo);
+  const playerStationInfo = useStore((s) => s.playerStationInfo);
+  const playerId = useStore((s) => s.playerId);
   const scanEvents = useStore((s) => s.scanEvents);
   const rescuedSurvivors = useStore((s) => s.rescuedSurvivors);
   const bookmarks = useStore((s) => s.bookmarks);
@@ -541,6 +544,9 @@ export function DetailPanel() {
         )}
         {isPlayerHere && jumpGateInfo && <JumpGatePanel gate={jumpGateInfo} />}
         {isPlayerHere && playerGateInfo && <PlayerGatePanel />}
+        {isPlayerHere && playerStationInfo && playerStationInfo.ownerId === playerId && (
+          <StationManagePanel station={playerStationInfo} />
+        )}
         {isPlayerHere && sector?.type === 'station' && (
           <>
             <button
@@ -784,6 +790,10 @@ export function DetailPanel() {
           {isPlayerHere && jumpGateInfo && <JumpGatePanel gate={jumpGateInfo} />}
           {/* Player-built jumpgate panel */}
           {isPlayerHere && playerGateInfo && <PlayerGatePanel />}
+          {/* Player station management */}
+          {isPlayerHere && playerStationInfo && playerStationInfo.ownerId === playerId && (
+            <StationManagePanel station={playerStationInfo} />
+          )}
 
           {/* Rescue button - distress signal scan event at this sector */}
           {isPlayerHere &&

--- a/packages/client/src/components/StationManagePanel.tsx
+++ b/packages/client/src/components/StationManagePanel.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from 'react';
+import { network } from '../network/client';
+import {
+  STATION_BUILD_COSTS,
+  STATION_MODULE_UPGRADE_COST,
+  MAX_STATION_LEVEL,
+} from '@void-sector/shared';
+import type { PlayerStation } from '@void-sector/shared';
+
+interface Props {
+  station: PlayerStation;
+}
+
+function formatCosts(costs: { credits: number; crystal: number; artefact: number }): string {
+  return `${costs.credits} CR · ${costs.crystal} CRYSTAL · ${costs.artefact} ARTEFAKT`;
+}
+
+export function StationManagePanel({ station }: Props) {
+  const [confirmUpgrade, setConfirmUpgrade] = useState<string | null>(null);
+
+  // Reset confirm on station change
+  useEffect(() => {
+    setConfirmUpgrade(null);
+  }, [station.level, station.factoryLevel, station.cargoLevel]);
+
+  const canUpgradeStation = station.level < MAX_STATION_LEVEL;
+  const nextStationCosts = canUpgradeStation
+    ? STATION_BUILD_COSTS[(station.level + 1) as keyof typeof STATION_BUILD_COSTS]
+    : null;
+
+  const canUpgradeFactory = station.factoryLevel < station.level;
+  const nextFactoryCost = canUpgradeFactory ? STATION_MODULE_UPGRADE_COST(station.factoryLevel + 1) : 0;
+
+  const canUpgradeCargo = station.cargoLevel < station.level;
+  const nextCargoCost = canUpgradeCargo ? STATION_MODULE_UPGRADE_COST(station.cargoLevel + 1) : 0;
+
+  const handleUpgrade = (key: string, action: () => void) => {
+    if (confirmUpgrade === key) {
+      action();
+      setConfirmUpgrade(null);
+    } else {
+      setConfirmUpgrade(key);
+    }
+  };
+
+  return (
+    <div style={{ padding: '8px 0', fontFamily: 'var(--font-mono)', fontSize: '0.7rem' }}>
+      <div style={{ letterSpacing: '0.1em', opacity: 0.6, marginBottom: 6 }}>
+        ─── STATION VERWALTUNG ───
+      </div>
+
+      {/* Station Level */}
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ color: '#FFB000', marginBottom: 4 }}>
+          STATION LEVEL: {station.level}/{MAX_STATION_LEVEL}
+        </div>
+        <div style={{
+          height: 4,
+          background: 'rgba(255,176,0,0.15)',
+          marginBottom: 4,
+        }}>
+          <div style={{
+            height: '100%',
+            width: `${(station.level / MAX_STATION_LEVEL) * 100}%`,
+            background: '#FFB000',
+          }} />
+        </div>
+        {canUpgradeStation && nextStationCosts && (
+          <button
+            className="vs-btn"
+            style={{
+              fontSize: '0.65rem',
+              borderColor: confirmUpgrade === 'station' ? '#00FF88' : undefined,
+              color: confirmUpgrade === 'station' ? '#00FF88' : undefined,
+            }}
+            onClick={() => handleUpgrade('station', () => network.sendUpgradeStation(station.id))}
+          >
+            {confirmUpgrade === 'station'
+              ? `[BESTÄTIGEN — ${formatCosts(nextStationCosts)}]`
+              : `[UPGRADE → LV${station.level + 1}] ${formatCosts(nextStationCosts)}`}
+          </button>
+        )}
+        {!canUpgradeStation && (
+          <div style={{ color: 'rgba(255,176,0,0.4)', fontSize: '0.6rem' }}>MAX LEVEL</div>
+        )}
+      </div>
+
+      {/* Factory Module */}
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ color: '#00BFFF', marginBottom: 4 }}>
+          FACTORY: LV {station.factoryLevel}/{station.level}
+        </div>
+        {station.factoryLevel > 0 && (
+          <div style={{
+            height: 3,
+            background: 'rgba(0,191,255,0.15)',
+            marginBottom: 4,
+          }}>
+            <div style={{
+              height: '100%',
+              width: `${(station.factoryLevel / station.level) * 100}%`,
+              background: '#00BFFF',
+            }} />
+          </div>
+        )}
+        {canUpgradeFactory && (
+          <button
+            className="vs-btn"
+            style={{
+              fontSize: '0.65rem',
+              borderColor: confirmUpgrade === 'factory' ? '#00FF88' : undefined,
+              color: confirmUpgrade === 'factory' ? '#00FF88' : undefined,
+            }}
+            onClick={() => handleUpgrade('factory', () =>
+              network.sendUpgradeStationModule(station.id, 'factory'),
+            )}
+          >
+            {confirmUpgrade === 'factory'
+              ? `[BESTÄTIGEN — ${nextFactoryCost} CR]`
+              : `[UPGRADE → LV${station.factoryLevel + 1}] ${nextFactoryCost} CR`}
+          </button>
+        )}
+        {!canUpgradeFactory && station.factoryLevel > 0 && (
+          <div style={{ color: 'rgba(0,191,255,0.4)', fontSize: '0.6rem' }}>
+            STATION LEVEL ERHÖHEN FÜR WEITERES UPGRADE
+          </div>
+        )}
+        {station.factoryLevel === 0 && !canUpgradeFactory && (
+          <div style={{ color: 'rgba(0,191,255,0.4)', fontSize: '0.6rem' }}>
+            STATION LEVEL ERHÖHEN UM FACTORY FREIZUSCHALTEN
+          </div>
+        )}
+      </div>
+
+      {/* Cargo Module */}
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ color: '#00FF88', marginBottom: 4 }}>
+          CARGO: LV {station.cargoLevel}/{station.level}
+        </div>
+        {station.cargoLevel > 0 && (
+          <div style={{
+            height: 3,
+            background: 'rgba(0,255,136,0.15)',
+            marginBottom: 4,
+          }}>
+            <div style={{
+              height: '100%',
+              width: `${(station.cargoLevel / station.level) * 100}%`,
+              background: '#00FF88',
+            }} />
+          </div>
+        )}
+        {canUpgradeCargo && (
+          <button
+            className="vs-btn"
+            style={{
+              fontSize: '0.65rem',
+              borderColor: confirmUpgrade === 'cargo' ? '#00FF88' : undefined,
+              color: confirmUpgrade === 'cargo' ? '#00FF88' : undefined,
+            }}
+            onClick={() => handleUpgrade('cargo', () =>
+              network.sendUpgradeStationModule(station.id, 'cargo'),
+            )}
+          >
+            {confirmUpgrade === 'cargo'
+              ? `[BESTÄTIGEN — ${nextCargoCost} CR]`
+              : `[UPGRADE → LV${station.cargoLevel + 1}] ${nextCargoCost} CR`}
+          </button>
+        )}
+        {!canUpgradeCargo && station.cargoLevel > 0 && (
+          <div style={{ color: 'rgba(0,255,136,0.4)', fontSize: '0.6rem' }}>
+            STATION LEVEL ERHÖHEN FÜR WEITERES UPGRADE
+          </div>
+        )}
+        {station.cargoLevel === 0 && !canUpgradeCargo && (
+          <div style={{ color: 'rgba(0,255,136,0.4)', fontSize: '0.6rem' }}>
+            STATION LEVEL ERHÖHEN UM CARGO FREIZUSCHALTEN
+          </div>
+        )}
+      </div>
+
+      <div style={{ fontSize: '0.55rem', color: 'rgba(255,176,0,0.3)', marginTop: 4 }}>
+        Sektor ({station.sectorX}, {station.sectorY}) · Quadrant ({station.quadrantX}:{station.quadrantY})
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -256,8 +256,9 @@ class GameNetwork {
       const store = useStore.getState();
       store.setCurrentSector(sector);
       store.addDiscoveries([sector]);
-      // Clear player gate info — server will re-send if new sector has a gate
+      // Clear player gate/station info — server will re-send if new sector has one
       store.setPlayerGateInfo(null);
+      useStore.setState({ playerStationInfo: null });
       // Sector type help tips
       if (sector.type === 'nebula') store.showTip('first_nebula');
       else if (sector.type === 'station') store.showTip('first_station');
@@ -1280,6 +1281,11 @@ class GameNetwork {
         useStore.getState().setPlayerGateInfo(data);
       },
     );
+
+    // Player station info (sent when entering a sector with a player station)
+    room.onMessage('playerStationInfo', (data: any) => {
+      useStore.setState({ playerStationInfo: data ?? null });
+    });
 
     // Player gate travel result
     room.onMessage(

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -506,6 +506,9 @@ export interface GameSlice {
   // Player Gates
   playerGateInfo: { gate: PlayerJumpGate; destinations: JumpGateDestination[] } | null;
 
+  // Player Stations
+  playerStationInfo: any | null;
+
   // Quadrant system
   knownQuadrants: Array<{
     qx: number;
@@ -826,6 +829,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
   playerStats: loadPlayerStats(),
   shipMoveAnimation: null,
   playerGateInfo: null,
+  playerStationInfo: null,
   knownQuadrants: [],
   currentQuadrant: null,
   firstContactEvent: null,

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -1496,6 +1496,9 @@ export class SectorRoom extends Room<SectorRoomState> {
       // Detect player-built jumpgate in sector
       await this.navigation.detectAndSendPlayerGate(client, sectorX, sectorY);
 
+      // Detect player station in sector
+      await this.navigation.detectAndSendPlayerStation(client, auth.userId, sectorX, sectorY);
+
       // Send initial hyperdrive state
       if (stats.hyperdriveRange > 0) {
         let hdState = await getHyperdriveState(auth.userId);

--- a/packages/server/src/rooms/services/NavigationService.ts
+++ b/packages/server/src/rooms/services/NavigationService.ts
@@ -55,6 +55,7 @@ import {
   recordNewsEvent,
   getAllQuadrantControls,
 } from '../../db/queries.js';
+import { getPlayerStationAt } from '../../db/stationQueries.js';
 import { civQueries } from '../../db/civQueries.js';
 import {
   getAPState,
@@ -160,6 +161,9 @@ export class NavigationService {
 
     // Check for player-built JumpGate at this sector
     await this.detectAndSendPlayerGate(client, sectorX, sectorY);
+
+    // Check for player station at this sector
+    await this.detectAndSendPlayerStation(client, auth.userId, sectorX, sectorY);
 
     // Quadrant first-contact detection
     await this.ctx.checkFirstContact(client, auth, sectorX, sectorY);
@@ -1241,6 +1245,30 @@ export class NavigationService {
         linkedGates: links,
       },
       destinations,
+    });
+  }
+
+  /**
+   * Detect player-owned station at sector and send info to client.
+   */
+  async detectAndSendPlayerStation(client: Client, userId: string, sectorX: number, sectorY: number): Promise<void> {
+    const station = await getPlayerStationAt(sectorX, sectorY);
+    if (!station) {
+      client.send('playerStationInfo', null);
+      return;
+    }
+    client.send('playerStationInfo', {
+      id: station.id,
+      ownerId: station.owner_id,
+      sectorX: station.sector_x,
+      sectorY: station.sector_y,
+      quadrantX: station.quadrant_x,
+      quadrantY: station.quadrant_y,
+      level: station.level,
+      factoryLevel: station.factory_level,
+      cargoLevel: station.cargo_level,
+      cargoContents: station.cargo_contents,
+      createdAt: new Date(station.created_at).getTime(),
     });
   }
 


### PR DESCRIPTION
## Summary
Part 2 of 4 for #403: Station management UI.

- **StationManagePanel** component: shows station level, factory/cargo module levels with progress bars and upgrade buttons
- **detectAndSendPlayerStation** in NavigationService: sends `playerStationInfo` when player enters their station sector  
- **Confirm pattern** for all upgrade actions (click once to preview cost, click again to confirm)
- **State management**: `playerStationInfo` in Zustand, cleared on sector change
- Integrated in DetailPanel alongside PlayerGatePanel

## Test plan
- [ ] Panel shows when player is at own station sector
- [ ] Station level upgrade with correct cost display
- [ ] Factory/cargo module upgrade (capped at station level)
- [ ] Confirm pattern works (2 clicks required)
- [ ] Panel disappears when leaving station sector

🤖 Generated with [Claude Code](https://claude.com/claude-code)
