### PR TITLE
fix: rulebook #386 — human starting territory 0:0-2:2 (was 0:0-4:4)

### DIFF
--- a/packages/server/src/engine/__tests__/livingUniverse.test.ts
+++ b/packages/server/src/engine/__tests__/livingUniverse.test.ts
@@ -21,7 +21,7 @@ import {
 describe('initializeTerritoryState', () => {
   it('seeds human starting territory correctly', () => {
     const state = initializeTerritoryState();
-    expect(state.factionQuadrants.get('humans')?.size).toBe(25);
+    expect(state.factionQuadrants.get('humans')?.size).toBe(9);
   });
 
   it('human territory includes 0:0', () => {
@@ -29,9 +29,9 @@ describe('initializeTerritoryState', () => {
     expect(state.dominantFactions.get('0:0')).toBe('humans');
   });
 
-  it('human territory includes 4:4', () => {
+  it('human territory includes 2:2', () => {
     const state = initializeTerritoryState();
-    expect(state.dominantFactions.get('4:4')).toBe('humans');
+    expect(state.dominantFactions.get('2:2')).toBe('humans');
   });
 
   it('alien factions have territory far from origin', () => {
@@ -142,7 +142,7 @@ describe('UniverseTickEngine', () => {
   it('returns dominant faction for seeded human quadrant', () => {
     const engine = new UniverseTickEngine();
     expect(engine.getDominantFaction(0, 0)).toBe('humans');
-    expect(engine.getDominantFaction(4, 4)).toBe('humans');
+    expect(engine.getDominantFaction(2, 2)).toBe('humans');
   });
 
   it('returns null for unclaimed quadrant', () => {
@@ -154,7 +154,7 @@ describe('UniverseTickEngine', () => {
   it('getFactionStats returns counts for all factions', () => {
     const engine = new UniverseTickEngine();
     const stats = engine.getFactionStats();
-    expect(stats['humans']).toBe(25);
+    expect(stats['humans']).toBe(9);
     expect(stats['axioms']).toBeGreaterThanOrEqual(0);
   });
 });
@@ -204,14 +204,14 @@ describe('cosmic faction constants', () => {
     expect(COSMIC_FACTION_IDS[0]).toBe('humans');
   });
 
-  it('has exactly 25 human starting territory quadrants', () => {
-    expect(HUMAN_STARTING_TERRITORY).toHaveLength(25);
+  it('has exactly 9 human starting territory quadrants', () => {
+    expect(HUMAN_STARTING_TERRITORY).toHaveLength(9);
   });
 
-  it('human territory covers 0:0 to 4:4', () => {
+  it('human territory covers 0:0 to 2:2', () => {
     const humanSet = new Set(HUMAN_STARTING_TERRITORY.map(([x, y]) => `${x}:${y}`));
-    for (let x = 0; x <= 4; x++) {
-      for (let y = 0; y <= 4; y++) {
+    for (let x = 0; x <= 2; x++) {
+      for (let y = 0; y <= 2; y++) {
         expect(humanSet.has(`${x}:${y}`)).toBe(true);
       }
     }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2249,7 +2249,7 @@ export const COSMIC_FACTION_IDS = [
 ] as const;
 export type CosmicFactionId = (typeof COSMIC_FACTION_IDS)[number];
 
-// Human starting territory: quadrants 0:0 to 4:4 (25 quadrants)
+// Human starting territory: quadrants 0:0 to 2:2 (9 quadrants)
 export const HUMAN_STARTING_TERRITORY: Array<[number, number]> = [
   [0, 0],
   [0, 1],
@@ -2260,22 +2260,6 @@ export const HUMAN_STARTING_TERRITORY: Array<[number, number]> = [
   [2, 0],
   [2, 1],
   [2, 2],
-  [0, 3],
-  [1, 3],
-  [2, 3],
-  [3, 0],
-  [3, 1],
-  [3, 2],
-  [3, 3],
-  [4, 0],
-  [4, 1],
-  [4, 2],
-  [4, 3],
-  [0, 4],
-  [1, 4],
-  [2, 4],
-  [3, 4],
-  [4, 4],
 ];
 
 // Alien starting regions (distant from humans, no overlap with 0:0–4:4)


### PR DESCRIPTION
## Summary
- Human Starting Territory: 25 Quadranten (0:0-4:4) → 9 Quadranten (0:0-2:2)
- Tests aktualisiert (27/27 pass)

Alles andere aus #386 bereits implementiert:
- Faction Upgrades bei honored: existieren (cargo_expansion, advanced_scanner, combat_plating, void_drive)
- Alien Aggression/Stil: in faction_config DB (K'thari=2.0, Silent Swarm=2.5, etc.)
- Rep-Quellen: 4 Eintragspunkte aktiv
- 11 kosmische Fraktionen mit Farben

Fixes #386