### PR TITLE
feat: #403 FABRIK tabs + blueprint consume — ACEP/STATION, consume into factory

### DIFF
--- a/packages/client/src/components/FabrikPanel.tsx
+++ b/packages/client/src/components/FabrikPanel.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
@@ -5,12 +6,12 @@ import { MODULES, SPECIALIZED_SLOT_INDEX } from '@void-sector/shared';
 
 const green = '#00FF88';
 const dimGreen = 'rgba(0,255,136,0.3)';
+const amber = '#FFB000';
 
 const panelStyle: React.CSSProperties = {
   padding: '8px 12px',
   fontFamily: 'var(--font-mono)',
   fontSize: '0.7rem',
-  color: green,
   overflowY: 'auto',
   height: '100%',
 };
@@ -29,7 +30,7 @@ const rowStyle: React.CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '3px 0',
-  borderBottom: `1px solid rgba(0,255,136,0.1)`,
+  borderBottom: 'rgba(0,255,136,0.1)',
   gap: 8,
   flexWrap: 'wrap',
 };
@@ -44,52 +45,77 @@ const btnStyle: React.CSSProperties = {
   cursor: 'pointer',
 };
 
-export function FabrikPanel() {
+function AcepTab() {
   const { t } = useTranslation('ui');
   const inventory = useStore((s) => s.inventory);
   const ship = useStore((s) => s.ship);
+  const acepBlueprints = useStore((s) => s.acepFactoryBlueprints);
 
-  const blueprints = inventory.filter((i) => i.itemType === 'blueprint');
+  useEffect(() => {
+    network.requestAcepBlueprints();
+  }, []);
+
+  const blueprintsInCargo = inventory.filter((i) => i.itemType === 'blueprint');
   const cargoModules = inventory.filter((i) => i.itemType === 'module');
   const installedIds = new Set((ship?.modules ?? []).map((m) => m.moduleId));
 
   return (
-    <div style={panelStyle}>
-      {/* Craft from blueprints */}
-      <div style={{ ...headerStyle, marginTop: 0 }}>{t('fabrik.craft')}</div>
-      {blueprints.length === 0 ? (
-        <div style={{ opacity: 0.4 }}>{t('fabrik.noBlueprints')}</div>
+    <div>
+      {/* Consumed blueprints — available for crafting */}
+      <div style={{ ...headerStyle, marginTop: 0, color: green }}>VERFÜGBARE REZEPTE</div>
+      {acepBlueprints.length === 0 ? (
+        <div style={{ opacity: 0.4, color: green }}>KEINE BLUEPRINTS EINGELEGT</div>
       ) : (
-        blueprints.map((bp) => (
-          <div key={bp.itemId} style={rowStyle}>
-            <span>{bp.itemId.toUpperCase().replace(/_/g, ' ')}</span>
-            <div style={{ display: 'flex', gap: 4 }}>
+        acepBlueprints.map((moduleId) => {
+          const mod = MODULES[moduleId];
+          if (!mod) return null;
+          return (
+            <div key={moduleId} style={rowStyle}>
+              <span style={{ color: green }}>{mod.name ?? moduleId}</span>
               <button
                 style={btnStyle}
-                onClick={() => network.sendActivateBlueprint(bp.itemId)}
-                title="Blaupause aktivieren (Forschungsbaum)"
-              >
-                {t('fabrik.activate')}
-              </button>
-              <button
-                style={btnStyle}
-                onClick={() => network.sendCraftModule(bp.itemId)}
-                title="Modul herstellen"
+                onClick={() => network.sendCraftModule(moduleId)}
               >
                 {t('fabrik.manufacture')}
               </button>
             </div>
-          </div>
-        ))
+          );
+        })
       )}
 
-      {/* Install cargo modules */}
+      {/* Blueprints in cargo — can be consumed */}
+      {blueprintsInCargo.length > 0 && (
+        <>
+          <div style={headerStyle}>BLUEPRINTS IM CARGO → EINLEGEN</div>
+          {blueprintsInCargo.map((bp) => (
+            <div key={bp.itemId} style={rowStyle}>
+              <span style={{ color: amber }}>{bp.itemId.toUpperCase().replace(/_/g, ' ')}</span>
+              <div style={{ display: 'flex', gap: 4 }}>
+                <button
+                  style={{ ...btnStyle, borderColor: amber, color: amber }}
+                  onClick={() => network.sendConsumeBlueprint('acep', bp.itemId)}
+                >
+                  [EINLEGEN]
+                </button>
+                <button
+                  style={btnStyle}
+                  onClick={() => network.sendActivateBlueprint(bp.itemId)}
+                >
+                  {t('fabrik.activate')}
+                </button>
+              </div>
+            </div>
+          ))}
+        </>
+      )}
+
+      {/* Cargo modules — install */}
       {cargoModules.length > 0 && (
         <>
           <div style={headerStyle}>{t('fabrik.fromCargo')}</div>
           {cargoModules.map((m) => (
             <div key={m.itemId} style={rowStyle}>
-              <span>
+              <span style={{ color: green }}>
                 {m.itemId.toUpperCase().replace(/_/g, ' ')} x{m.quantity}
               </span>
               <button
@@ -108,11 +134,108 @@ export function FabrikPanel() {
         </>
       )}
 
-      {blueprints.length === 0 && cargoModules.length === 0 && (
-        <div style={{ opacity: 0.4, marginTop: 8 }}>
+      {acepBlueprints.length === 0 && blueprintsInCargo.length === 0 && cargoModules.length === 0 && (
+        <div style={{ opacity: 0.4, marginTop: 8, color: green }}>
           {t('fabrik.noModulesOrBlueprints')}
         </div>
       )}
+    </div>
+  );
+}
+
+function StationTab() {
+  const [selectedStation, setSelectedStation] = useState<string | null>(null);
+  const [stationBlueprints, setStationBlueprints] = useState<string[]>([]);
+  const [stations, setStations] = useState<any[]>([]);
+  const inventory = useStore((s) => s.inventory);
+
+  useEffect(() => {
+    network.requestMyStations();
+    const handler = (e: MessageEvent) => {
+      // Listen for myStations response
+    };
+    return () => {};
+  }, []);
+
+  // Listen for station list
+  useEffect(() => {
+    const unsub = useStore.subscribe((state) => {
+      // We'd need myStations in state — for now use a simple approach
+    });
+    return unsub;
+  }, []);
+
+  // Request station list on mount
+  useEffect(() => {
+    network.requestMyStations();
+  }, []);
+
+  const blueprintsInCargo = inventory.filter((i) => i.itemType === 'blueprint');
+
+  return (
+    <div>
+      <div style={{ ...headerStyle, marginTop: 0, color: '#00BFFF' }}>STATIONEN</div>
+      <div style={{ opacity: 0.4, color: '#00BFFF', fontSize: '0.6rem' }}>
+        Wähle eine Station mit ausgebauter Factory.
+        Blueprints aus dem Cargo können in die Station-Factory eingelegt werden.
+      </div>
+
+      {/* Station selection would go here — requires myStations in store */}
+      <div style={{ marginTop: 8, color: 'rgba(0,191,255,0.5)', fontSize: '0.6rem' }}>
+        Station-Produktion kommt in einem zukünftigen Update.
+        Nutze die VERWALTUNG im Detail-Panel um Factory auszubauen.
+      </div>
+
+      {blueprintsInCargo.length > 0 && selectedStation && (
+        <>
+          <div style={{ ...headerStyle, color: '#00BFFF' }}>BLUEPRINTS EINLEGEN</div>
+          {blueprintsInCargo.map((bp) => (
+            <div key={bp.itemId} style={rowStyle}>
+              <span style={{ color: amber }}>{bp.itemId.toUpperCase().replace(/_/g, ' ')}</span>
+              <button
+                style={{ ...btnStyle, borderColor: '#00BFFF', color: '#00BFFF' }}
+                onClick={() => network.sendConsumeBlueprint('station', bp.itemId, selectedStation)}
+              >
+                [EINLEGEN]
+              </button>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function FabrikPanel() {
+  const [tab, setTab] = useState<'acep' | 'station'>('acep');
+
+  return (
+    <div style={panelStyle}>
+      {/* Tab bar */}
+      <div style={{ display: 'flex', gap: 2, marginBottom: 8 }}>
+        {(['acep', 'station'] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            style={{
+              flex: 1,
+              background: tab === t ? (t === 'acep' ? green : '#00BFFF') : 'transparent',
+              color: tab === t ? '#000' : (t === 'acep' ? green : '#00BFFF'),
+              border: `1px solid ${t === 'acep' ? green : '#00BFFF'}`,
+              padding: '3px 6px',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.65rem',
+              letterSpacing: '0.1em',
+            }}
+          >
+            {t.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'acep' && <AcepTab />}
+      {tab === 'station' && <StationTab />}
     </div>
   );
 }

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -771,6 +771,21 @@ class GameNetwork {
       }
     });
 
+    room.onMessage('consumeBlueprintResult', (data: any) => {
+      const store = useStore.getState();
+      if (data.success) {
+        store.addLogEntry('BLUEPRINT EINGELEGT');
+        if (data.target === 'acep' && data.blueprints) {
+          useStore.setState({ acepFactoryBlueprints: data.blueprints });
+        }
+      } else {
+        store.addLogEntry(`BLUEPRINT FEHLER: ${data.error}`);
+      }
+    });
+    room.onMessage('acepBlueprints', (data: { blueprints: string[] }) => {
+      useStore.setState({ acepFactoryBlueprints: data.blueprints });
+    });
+
     // Credits update
     room.onMessage('creditsUpdate', (data: { credits: number }) => {
       useStore.getState().setCredits(data.credits);
@@ -2111,6 +2126,14 @@ class GameNetwork {
 
   requestStationDetails(stationId: string) {
     this.sectorRoom?.send('getStationDetails', { stationId });
+  }
+
+  requestAcepBlueprints() {
+    this.sectorRoom?.send('getAcepBlueprints');
+  }
+
+  sendConsumeBlueprint(target: 'acep' | 'station', moduleId: string, stationId?: string) {
+    this.sectorRoom?.send('consumeBlueprint', { target, moduleId, stationId });
   }
 
   sendDepositConstruction(siteId: string, ore: number, gas: number, crystal: number) {

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -508,6 +508,7 @@ export interface GameSlice {
 
   // Player Stations
   playerStationInfo: any | null;
+  acepFactoryBlueprints: string[];
 
   // Quadrant system
   knownQuadrants: Array<{
@@ -830,6 +831,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
   shipMoveAnimation: null,
   playerGateInfo: null,
   playerStationInfo: null,
+  acepFactoryBlueprints: [],
   knownQuadrants: [],
   currentQuadrant: null,
   firstContactEvent: null,

--- a/packages/server/src/db/migrations/069_station_blueprints.sql
+++ b/packages/server/src/db/migrations/069_station_blueprints.sql
@@ -1,0 +1,19 @@
+-- Blueprints consumed into station factories
+CREATE TABLE IF NOT EXISTS station_blueprints (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  station_id UUID NOT NULL REFERENCES player_stations(id) ON DELETE CASCADE,
+  module_id VARCHAR(64) NOT NULL,
+  consumed_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(station_id, module_id)
+);
+CREATE INDEX IF NOT EXISTS idx_station_blueprints_station ON station_blueprints(station_id);
+
+-- ACEP (ship) consumed blueprints — stored per player
+CREATE TABLE IF NOT EXISTS acep_blueprints (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  player_id UUID NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+  module_id VARCHAR(64) NOT NULL,
+  consumed_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(player_id, module_id)
+);
+CREATE INDEX IF NOT EXISTS idx_acep_blueprints_player ON acep_blueprints(player_id);

--- a/packages/server/src/db/stationQueries.ts
+++ b/packages/server/src/db/stationQueries.ts
@@ -87,3 +87,45 @@ export async function getPlayerStationById(stationId: string): Promise<PlayerSta
   );
   return result.rows[0] ?? null;
 }
+
+// ── Blueprint Memory ─────────────────────────────────────────────────
+
+export async function getStationBlueprints(stationId: string): Promise<string[]> {
+  const result = await query<{ module_id: string }>(
+    'SELECT module_id FROM station_blueprints WHERE station_id = $1 ORDER BY consumed_at ASC',
+    [stationId],
+  );
+  return result.rows.map((r) => r.module_id);
+}
+
+export async function consumeBlueprintIntoStation(stationId: string, moduleId: string): Promise<boolean> {
+  try {
+    await query(
+      'INSERT INTO station_blueprints (station_id, module_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [stationId, moduleId],
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getAcepBlueprints(playerId: string): Promise<string[]> {
+  const result = await query<{ module_id: string }>(
+    'SELECT module_id FROM acep_blueprints WHERE player_id = $1 ORDER BY consumed_at ASC',
+    [playerId],
+  );
+  return result.rows.map((r) => r.module_id);
+}
+
+export async function consumeBlueprintIntoAcep(playerId: string, moduleId: string): Promise<boolean> {
+  try {
+    await query(
+      'INSERT INTO acep_blueprints (player_id, module_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [playerId, moduleId],
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -825,6 +825,12 @@ export class SectorRoom extends Room<SectorRoomState> {
     this.onMessage('getStationDetails', async (client, data) => {
       await this.world.handleGetStationDetails(client, data);
     });
+    this.onMessage('getAcepBlueprints', async (client) => {
+      await this.world.handleGetAcepBlueprints(client);
+    });
+    this.onMessage('consumeBlueprint', async (client, data) => {
+      await this.world.handleConsumeBlueprint(client, data);
+    });
     this.onMessage('depositConstruction', async (client, data: DepositConstructionMessage) => {
       await this.world.handleDepositConstruction(client, data);
     });

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -76,6 +76,10 @@ import {
   insertPlayerStation,
   upgradeStationLevel as dbUpgradeStationLevel,
   upgradeStationModule as dbUpgradeStationModule,
+  getStationBlueprints as getStationBlueprintsList,
+  consumeBlueprintIntoStation as consumeBlueprintInStation,
+  getAcepBlueprints as getAcepBlueprintsList,
+  consumeBlueprintIntoAcep as consumeBlueprintInAcep,
 } from '../../db/stationQueries.js';
 import {
   getAPState,
@@ -146,6 +150,7 @@ import {
   getCargoState,
   addToInventory,
   removeFromInventory,
+  getInventoryItem,
 } from '../../engine/inventoryService.js';
 import {
   getPlayerKnownQuadrants,
@@ -650,7 +655,56 @@ export class WorldService {
       client.send('stationDetails', { station: null });
       return;
     }
-    client.send('stationDetails', { station });
+    const blueprints = await getStationBlueprintsList(data.stationId);
+    client.send('stationDetails', { station, blueprints });
+  }
+
+  async handleGetAcepBlueprints(client: Client): Promise<void> {
+    const auth = client.auth as AuthPayload;
+    const blueprints = await getAcepBlueprintsList(auth.userId);
+    client.send('acepBlueprints', { blueprints });
+  }
+
+  async handleConsumeBlueprint(
+    client: Client,
+    data: { target: 'acep' | 'station'; stationId?: string; moduleId: string },
+  ): Promise<void> {
+    if (rejectGuest(client, 'Blueprint einlegen')) return;
+    const auth = client.auth as AuthPayload;
+
+    const qty = await getInventoryItem(auth.userId, 'blueprint', data.moduleId);
+    if (qty < 1) {
+      client.send('consumeBlueprintResult', { success: false, error: 'Blueprint nicht im Inventar' });
+      return;
+    }
+
+    if (data.target === 'station') {
+      if (!data.stationId) {
+        client.send('consumeBlueprintResult', { success: false, error: 'Keine Station angegeben' });
+        return;
+      }
+      const station = await getPlayerStationById(data.stationId);
+      if (!station || station.owner_id !== auth.userId) {
+        client.send('consumeBlueprintResult', { success: false, error: 'Station nicht gefunden' });
+        return;
+      }
+      if (station.factory_level < 1) {
+        client.send('consumeBlueprintResult', { success: false, error: 'Factory-Modul nicht ausgebaut' });
+        return;
+      }
+      await removeFromInventory(auth.userId, 'blueprint', data.moduleId, 1);
+      await consumeBlueprintInStation(data.stationId, data.moduleId);
+      const blueprints = await getStationBlueprintsList(data.stationId);
+      client.send('consumeBlueprintResult', { success: true, target: 'station', blueprints });
+    } else {
+      await removeFromInventory(auth.userId, 'blueprint', data.moduleId, 1);
+      await consumeBlueprintInAcep(auth.userId, data.moduleId);
+      const blueprints = await getAcepBlueprintsList(auth.userId);
+      client.send('consumeBlueprintResult', { success: true, target: 'acep', blueprints });
+    }
+
+    client.send('inventoryUpdated', {});
+    client.send('logEntry', `BLUEPRINT EINGELEGT: ${data.moduleId} → ${data.target.toUpperCase()}`);
   }
 
   // ── Jumpgate Build ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Part 3 of 4 for #403: FABRIK program rework with tabs and blueprint consume system.

- **Migration 069**: `station_blueprints` + `acep_blueprints` tables for blueprint memory per factory
- **Blueprint consume**: Player can [EINLEGEN] a blueprint from cargo into ACEP or Station factory, making it permanently available as a recipe
- **FabrikPanel rewrite**: Two tabs (ACEP / STATION)
  - ACEP tab: shows consumed blueprints as craftable recipes + cargo blueprints with [EINLEGEN] + cargo modules with [INSTALLIEREN]
  - STATION tab: placeholder for future station production
- **Server handlers**: `handleConsumeBlueprint` (validates ownership, factory level, removes from inventory, adds to blueprint memory), `handleGetAcepBlueprints`
- **Client state**: `acepFactoryBlueprints` in Zustand

## Test plan
- [ ] FABRIK shows ACEP/STATION tabs
- [ ] [EINLEGEN] consumes blueprint from cargo into ACEP factory
- [ ] Consumed blueprint appears in VERFÜGBARE REZEPTE
- [ ] [HERSTELLEN] crafts module from consumed blueprint
- [ ] Station tab shows placeholder message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
