### PR TITLE
feat: #403 station production queue — produce modules at player stations

### DIFF
--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -785,6 +785,17 @@ class GameNetwork {
     room.onMessage('acepBlueprints', (data: { blueprints: string[] }) => {
       useStore.setState({ acepFactoryBlueprints: data.blueprints });
     });
+    room.onMessage('productionResult', (data: any) => {
+      const store = useStore.getState();
+      if (data.success) {
+        store.addLogEntry(data.instant ? 'PRODUZIERT' : 'PRODUKTION GESTARTET');
+      } else {
+        store.addLogEntry(`PRODUKTION FEHLER: ${data.error}`);
+      }
+    });
+    room.onMessage('productionQueue', (data: { jobs: any[] }) => {
+      useStore.setState({ productionQueue: data.jobs });
+    });
 
     // Credits update
     room.onMessage('creditsUpdate', (data: { credits: number }) => {
@@ -2134,6 +2145,14 @@ class GameNetwork {
 
   sendConsumeBlueprint(target: 'acep' | 'station', moduleId: string, stationId?: string) {
     this.sectorRoom?.send('consumeBlueprint', { target, moduleId, stationId });
+  }
+
+  sendStartProduction(stationId: string, moduleId: string, quantity: number) {
+    this.sectorRoom?.send('startProduction', { stationId, moduleId, quantity });
+  }
+
+  requestProductionQueue(stationId: string) {
+    this.sectorRoom?.send('getProductionQueue', { stationId });
   }
 
   sendDepositConstruction(siteId: string, ore: number, gas: number, crystal: number) {

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -509,6 +509,7 @@ export interface GameSlice {
   // Player Stations
   playerStationInfo: any | null;
   acepFactoryBlueprints: string[];
+  productionQueue: any[];
 
   // Quadrant system
   knownQuadrants: Array<{
@@ -832,6 +833,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
   playerGateInfo: null,
   playerStationInfo: null,
   acepFactoryBlueprints: [],
+  productionQueue: [],
   knownQuadrants: [],
   currentQuadrant: null,
   firstContactEvent: null,

--- a/packages/server/src/db/migrations/070_station_production.sql
+++ b/packages/server/src/db/migrations/070_station_production.sql
@@ -1,0 +1,12 @@
+-- Station production queue
+CREATE TABLE IF NOT EXISTS station_production_queue (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  station_id UUID NOT NULL REFERENCES player_stations(id) ON DELETE CASCADE,
+  module_id VARCHAR(64) NOT NULL,
+  quantity INTEGER NOT NULL CHECK (quantity BETWEEN 1 AND 9),
+  completed INTEGER NOT NULL DEFAULT 0,
+  started_at BIGINT NOT NULL,
+  time_per_item_ms BIGINT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_station_prod_queue_station ON station_production_queue(station_id);

--- a/packages/server/src/db/stationQueries.ts
+++ b/packages/server/src/db/stationQueries.ts
@@ -118,6 +118,62 @@ export async function getAcepBlueprints(playerId: string): Promise<string[]> {
   return result.rows.map((r) => r.module_id);
 }
 
+// ── Production Queue ─────────────────────────────────────────────────
+
+export interface ProductionQueueRow {
+  id: string;
+  station_id: string;
+  module_id: string;
+  quantity: number;
+  completed: number;
+  started_at: number;
+  time_per_item_ms: number;
+}
+
+export async function getProductionQueue(stationId: string): Promise<ProductionQueueRow[]> {
+  const result = await query<ProductionQueueRow>(
+    'SELECT * FROM station_production_queue WHERE station_id = $1 ORDER BY created_at ASC',
+    [stationId],
+  );
+  return result.rows;
+}
+
+export async function insertProductionJob(
+  stationId: string,
+  moduleId: string,
+  quantity: number,
+  startedAt: number,
+  timePerItemMs: number,
+): Promise<ProductionQueueRow> {
+  const result = await query<ProductionQueueRow>(
+    `INSERT INTO station_production_queue (station_id, module_id, quantity, started_at, time_per_item_ms)
+     VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+    [stationId, moduleId, quantity, startedAt, timePerItemMs],
+  );
+  return result.rows[0];
+}
+
+export async function updateProductionCompleted(jobId: string, completed: number): Promise<void> {
+  await query(
+    'UPDATE station_production_queue SET completed = $2 WHERE id = $1',
+    [jobId, completed],
+  );
+}
+
+export async function deleteProductionJob(jobId: string): Promise<void> {
+  await query('DELETE FROM station_production_queue WHERE id = $1', [jobId]);
+}
+
+export async function updateStationCargo(
+  stationId: string,
+  cargoContents: Record<string, number>,
+): Promise<void> {
+  await query(
+    'UPDATE player_stations SET cargo_contents = $2::jsonb WHERE id = $1',
+    [stationId, JSON.stringify(cargoContents)],
+  );
+}
+
 export async function consumeBlueprintIntoAcep(playerId: string, moduleId: string): Promise<boolean> {
   try {
     await query(

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -831,6 +831,12 @@ export class SectorRoom extends Room<SectorRoomState> {
     this.onMessage('consumeBlueprint', async (client, data) => {
       await this.world.handleConsumeBlueprint(client, data);
     });
+    this.onMessage('startProduction', async (client, data) => {
+      await this.world.handleStartProduction(client, data);
+    });
+    this.onMessage('getProductionQueue', async (client, data) => {
+      await this.world.handleGetProductionQueue(client, data);
+    });
     this.onMessage('depositConstruction', async (client, data: DepositConstructionMessage) => {
       await this.world.handleDepositConstruction(client, data);
     });

--- a/packages/server/src/rooms/services/WorldService.ts
+++ b/packages/server/src/rooms/services/WorldService.ts
@@ -67,6 +67,11 @@ import {
   STATION_BUILD_COSTS,
   STATION_MODULE_UPGRADE_COST,
   MAX_STATION_LEVEL,
+  MODULES,
+  PRODUCTION_MAX_QUEUE,
+  BASIC_FACTORY_RECIPES,
+  calculateProductionTime,
+  calculateCostMultiplier,
 } from '@void-sector/shared';
 import {
   getPlayerStationAt,
@@ -80,6 +85,11 @@ import {
   consumeBlueprintIntoStation as consumeBlueprintInStation,
   getAcepBlueprints as getAcepBlueprintsList,
   consumeBlueprintIntoAcep as consumeBlueprintInAcep,
+  getProductionQueue as getProductionQueueRows,
+  insertProductionJob as insertProductionJobRow,
+  updateProductionCompleted as updateProductionCompletedRow,
+  deleteProductionJob as deleteProductionJobRow,
+  updateStationCargo as updateStationCargoContents,
 } from '../../db/stationQueries.js';
 import {
   getAPState,
@@ -705,6 +715,156 @@ export class WorldService {
 
     client.send('inventoryUpdated', {});
     client.send('logEntry', `BLUEPRINT EINGELEGT: ${data.moduleId} → ${data.target.toUpperCase()}`);
+  }
+
+  // ── Station Production ──────────────────────────────────────────────
+
+  async handleStartProduction(
+    client: Client,
+    data: { stationId: string; moduleId: string; quantity: number },
+  ): Promise<void> {
+    if (rejectGuest(client, 'Produzieren')) return;
+    const auth = client.auth as AuthPayload;
+
+    const station = await getPlayerStationById(data.stationId);
+    if (!station || station.owner_id !== auth.userId) {
+      client.send('productionResult', { success: false, error: 'Station nicht gefunden' });
+      return;
+    }
+    if (station.factory_level < 1) {
+      client.send('productionResult', { success: false, error: 'Factory nicht ausgebaut' });
+      return;
+    }
+
+    const qty = Math.max(1, Math.min(PRODUCTION_MAX_QUEUE, data.quantity));
+
+    // Check if this is a basic recipe
+    const basicRecipe = BASIC_FACTORY_RECIPES[data.moduleId];
+    if (basicRecipe) {
+      // Check station cargo has enough inputs
+      const cargo = station.cargo_contents ?? {};
+      for (const [res, needed] of Object.entries(basicRecipe.inputs)) {
+        if ((cargo[res] ?? 0) < needed * qty) {
+          client.send('productionResult', { success: false, error: `Nicht genug ${res.toUpperCase()} im Stationslager` });
+          return;
+        }
+      }
+      // Deduct inputs from station cargo
+      const newCargo = { ...cargo };
+      for (const [res, needed] of Object.entries(basicRecipe.inputs)) {
+        newCargo[res] = (newCargo[res] ?? 0) - needed * qty;
+      }
+      // Add outputs to station cargo
+      for (const [res, amount] of Object.entries(basicRecipe.outputs)) {
+        newCargo[res] = (newCargo[res] ?? 0) + amount * qty;
+      }
+      await updateStationCargoContents(data.stationId, newCargo);
+      client.send('productionResult', { success: true, instant: true, stationCargo: newCargo });
+      client.send('logEntry', `PRODUZIERT: ${qty}x ${data.moduleId.toUpperCase()}`);
+      return;
+    }
+
+    // Module production from consumed blueprint
+    const blueprints = await getStationBlueprintsList(data.stationId);
+    if (!blueprints.includes(data.moduleId)) {
+      client.send('productionResult', { success: false, error: 'Blueprint nicht in dieser Factory' });
+      return;
+    }
+
+    const mod = MODULES[data.moduleId];
+    if (!mod || !mod.cost) {
+      client.send('productionResult', { success: false, error: 'Modul nicht herstellbar' });
+      return;
+    }
+
+    // Calculate costs with tier multiplier
+    const costMult = calculateCostMultiplier(mod.tier, station.factory_level);
+    const cargo = station.cargo_contents ?? {};
+
+    // Check resources in station cargo
+    for (const [res, base] of Object.entries(mod.cost)) {
+      if (res === 'credits') continue;
+      const needed = Math.ceil((base as number) * costMult) * qty;
+      if ((cargo[res] ?? 0) < needed) {
+        client.send('productionResult', { success: false, error: `Nicht genug ${res.toUpperCase()} (${needed} benötigt)` });
+        return;
+      }
+    }
+
+    // Check credits
+    const creditCost = Math.ceil((mod.cost.credits ?? 0) * costMult) * qty;
+    if (creditCost > 0) {
+      const credits = await getPlayerCredits(auth.userId);
+      if (credits < creditCost) {
+        client.send('productionResult', { success: false, error: `Nicht genug Credits (${creditCost} benötigt)` });
+        return;
+      }
+      await deductCredits(auth.userId, creditCost);
+    }
+
+    // Deduct resources from station cargo
+    const newCargo = { ...cargo };
+    for (const [res, base] of Object.entries(mod.cost)) {
+      if (res === 'credits') continue;
+      const needed = Math.ceil((base as number) * costMult) * qty;
+      newCargo[res] = (newCargo[res] ?? 0) - needed;
+    }
+    await updateStationCargoContents(data.stationId, newCargo);
+
+    // Add to production queue
+    const timePerItem = calculateProductionTime(mod.tier, station.factory_level);
+    const job = await insertProductionJobRow(data.stationId, data.moduleId, qty, Date.now(), timePerItem);
+
+    client.send('productionResult', {
+      success: true,
+      job: { id: job.id, moduleId: data.moduleId, quantity: qty, completed: 0, timePerItemMs: timePerItem },
+      stationCargo: newCargo,
+    });
+    if (creditCost > 0) {
+      client.send('creditsUpdate', { credits: await getPlayerCredits(auth.userId) });
+    }
+    client.send('logEntry', `PRODUKTION GESTARTET: ${qty}x ${mod.name ?? data.moduleId}`);
+  }
+
+  async handleGetProductionQueue(client: Client, data: { stationId: string }): Promise<void> {
+    const auth = client.auth as AuthPayload;
+    const station = await getPlayerStationById(data.stationId);
+    if (!station || station.owner_id !== auth.userId) {
+      client.send('productionQueue', { jobs: [] });
+      return;
+    }
+
+    const jobs = await getProductionQueueRows(data.stationId);
+    const now = Date.now();
+
+    // Lazy evaluation: calculate completed items
+    const updatedJobs = [];
+    for (const job of jobs) {
+      const elapsed = now - job.started_at;
+      const newCompleted = Math.min(job.quantity, Math.floor(elapsed / job.time_per_item_ms));
+      if (newCompleted > job.completed) {
+        await updateProductionCompletedRow(job.id, newCompleted);
+        // Add produced modules to station cargo
+        const cargo = (await getPlayerStationById(data.stationId))?.cargo_contents ?? {};
+        const produced = newCompleted - job.completed;
+        cargo[job.module_id] = (cargo[job.module_id] ?? 0) + produced;
+        await updateStationCargoContents(data.stationId, cargo);
+      }
+      if (newCompleted >= job.quantity) {
+        await deleteProductionJobRow(job.id);
+      } else {
+        updatedJobs.push({
+          id: job.id,
+          moduleId: job.module_id,
+          quantity: job.quantity,
+          completed: newCompleted,
+          timePerItemMs: job.time_per_item_ms,
+          startedAt: job.started_at,
+        });
+      }
+    }
+
+    client.send('productionQueue', { jobs: updatedJobs });
   }
 
   // ── Jumpgate Build ─────────────────────────────────────────────────

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -111,6 +111,33 @@ export const STATION_BUILD_COSTS: Record<number, { credits: number; crystal: num
 
 export const STATION_MODULE_UPGRADE_COST = (level: number): number => 200 * level * level;
 
+// Station production
+export const PRODUCTION_BASE_TIME_MS = 60_000; // 60s base per item
+export const PRODUCTION_TIER_COST_FACTOR = 2; // cost multiplier per tier above factory level
+export const PRODUCTION_MAX_QUEUE = 9;
+
+/** Basic recipes available to every factory (no blueprint needed) */
+export const BASIC_FACTORY_RECIPES: Record<string, { inputs: Record<string, number>; outputs: Record<string, number>; timeMs: number }> = {
+  fuel: { inputs: { gas: 4 }, outputs: { fuel: 100 }, timeMs: 30_000 },
+};
+
+/**
+ * Calculate production time for a module at a given factory level.
+ * Tier difference increases time exponentially.
+ */
+export function calculateProductionTime(moduleTier: number, factoryLevel: number): number {
+  const tierDiff = Math.max(0, moduleTier - factoryLevel);
+  return PRODUCTION_BASE_TIME_MS * moduleTier * Math.pow(PRODUCTION_TIER_COST_FACTOR, tierDiff);
+}
+
+/**
+ * Calculate resource cost multiplier for producing above factory level.
+ */
+export function calculateCostMultiplier(moduleTier: number, factoryLevel: number): number {
+  const tierDiff = Math.max(0, moduleTier - factoryLevel);
+  return Math.pow(PRODUCTION_TIER_COST_FACTOR, tierDiff);
+}
+
 // ── Research Lab / Wissen ─────────────────────────────────────────────
 
 /** Lab tier Wissen multiplier for active generation (replaces passive tick) */


### PR DESCRIPTION
## Summary
Part 4 of 4 for #403: Station production system.

- **Migration 070**: `station_production_queue` table
- **Production engine**: Resources deducted from station cargo, modules produced over time (lazy evaluation)
- **Tier cost scaling**: Factory level < module tier → exponential cost increase (×2 per tier difference)
- **Basic recipe**: FUEL (4 GAS → 100 FUEL, instant, no blueprint needed)
- **handleStartProduction**: validates blueprints in station memory, checks/deducts resources from station cargo, creates queue job
- **handleGetProductionQueue**: lazy evaluation — calculates completed items on demand, adds to station cargo, cleans up finished jobs
- **Client**: network methods + Zustand state for productionQueue

Closes #403

## Production time formula
`BASE_TIME (60s) × moduleTier × 2^(tierDiff)`

Example: Tier 3 module at Factory Lv2 → 60s × 3 × 2^1 = 360s (6 min)

## Test plan
- [x] Constants tests pass
- [x] Shared builds clean
- [ ] Start production at station with consumed blueprint
- [ ] Resources deducted from station cargo
- [ ] Queue shows in-progress jobs
- [ ] Completed items appear in station cargo
- [ ] Basic FUEL recipe works instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
