### PR TITLE
feat: blueprint as quest reward — rewardBlueprint field, duplicate fallback (#406)

### DIFF
--- a/packages/client/src/components/QuestDetailPanel.tsx
+++ b/packages/client/src/components/QuestDetailPanel.tsx
@@ -164,6 +164,11 @@ export function QuestDetailPanel() {
       <div>{quest.rewards.credits} CR</div>
       <div>{quest.rewards.xp} XP</div>
       {quest.rewards.reputation > 0 && <div>+{quest.rewards.reputation} REP</div>}
+      {quest.rewards.rewardBlueprint && (
+        <div style={{ color: '#AA88FF', fontSize: '0.7rem', marginTop: 4 }}>
+          BLUEPRINT: {quest.rewards.rewardBlueprint.toUpperCase().replace(/_/g, ' ')}
+        </div>
+      )}
 
       <button
         className="vs-btn"

--- a/packages/client/src/components/QuestsScreen.tsx
+++ b/packages/client/src/components/QuestsScreen.tsx
@@ -847,6 +847,11 @@ export function QuestsScreen() {
                           {q.rewards.artefactChance ? ` | ${Math.round(q.rewards.artefactChance * 100)}% ARTEFAKT` : ''}
                           {q.rewards.blueprintChance ? ` | ${Math.round(q.rewards.blueprintChance * 100)}% BLUEPRINT` : ''}
                         </div>
+                        {q.rewards.rewardBlueprint && (
+                          <div style={{ color: '#AA88FF', fontSize: '0.5rem', marginTop: '2px' }}>
+                            BLUEPRINT: {q.rewards.rewardBlueprint.toUpperCase().replace(/_/g, ' ')}
+                          </div>
+                        )}
                         <button
                           className="vs-btn"
                           onClick={() => confirm(`abandon-${q.id}`, () => network.sendAbandonQuest(q.id))}
@@ -1021,6 +1026,11 @@ export function QuestsScreen() {
                           {q.rewards.artefactChance ? ` | ${Math.round(q.rewards.artefactChance * 100)}% ARTEFAKT` : ''}
                           {q.rewards.blueprintChance ? ` | ${Math.round(q.rewards.blueprintChance * 100)}% BLUEPRINT` : ''}
                         </div>
+                        {q.rewards.rewardBlueprint && (
+                          <div style={{ color: '#AA88FF', fontSize: '0.5rem', paddingLeft: '6px', marginTop: '2px' }}>
+                            BLUEPRINT: {q.rewards.rewardBlueprint.toUpperCase().replace(/_/g, ' ')}
+                          </div>
+                        )}
                       </div>
                     )}
                     {armed ? (

--- a/packages/client/src/components/overlays/QuestCompleteOverlay.tsx
+++ b/packages/client/src/components/overlays/QuestCompleteOverlay.tsx
@@ -60,6 +60,11 @@ export function QuestCompleteOverlay() {
         {current.rewards.wissen ? ` · +${current.rewards.wissen} Wissen` : ''}
         {current.rewards.reputation ? ` · +${current.rewards.reputation} REP` : ''}
       </div>
+      {current.rewards.rewardBlueprint && (
+        <div style={{ color: '#AA88FF', fontSize: '0.6rem', marginTop: 4 }}>
+          BLUEPRINT: {current.rewards.rewardBlueprint.toUpperCase().replace(/_/g, ' ')}
+        </div>
+      )}
       <div
         style={{ color: 'rgba(255,255,255,0.2)', fontSize: '0.55rem', marginTop: 6, textAlign: 'right' }}
       >

--- a/packages/server/src/engine/questTemplates.ts
+++ b/packages/server/src/engine/questTemplates.ts
@@ -20,6 +20,8 @@ export interface QuestTemplate {
   scanAdjacentCount?: number;
   /** For bounty_chase quests: [min, max] pirate level */
   targetLevelRange?: [number, number];
+  /** Specific blueprint (moduleId) awarded on completion */
+  rewardBlueprint?: string;
 }
 
 export const QUEST_TEMPLATES: QuestTemplate[] = [
@@ -77,6 +79,7 @@ export const QUEST_TEMPLATES: QuestTemplate[] = [
     rewardRepBase: 20,
     rewardWissenBase: 2,
     distanceRange: [10, 40],
+    rewardBlueprint: 'module_cargo_mk3',
   },
   // Scientist quests
   {
@@ -119,6 +122,7 @@ export const QUEST_TEMPLATES: QuestTemplate[] = [
     distanceRange: [20, 50],
     rivalFactionId: 'pirates',
     rivalRepPenalty: 5,
+    rewardBlueprint: 'module_scanner_mk3',
   },
   // Pirate quests
   {
@@ -176,6 +180,7 @@ export const QUEST_TEMPLATES: QuestTemplate[] = [
     targetLevelRange: [4, 6],
     rivalFactionId: 'traders',
     rivalRepPenalty: 5,
+    rewardBlueprint: 'module_shield_mk3',
   },
   // Ancient quests (rare)
   {

--- a/packages/server/src/engine/questgen.ts
+++ b/packages/server/src/engine/questgen.ts
@@ -198,6 +198,7 @@ function fillQuestTemplate(
       reputationPenalty: template.rivalRepPenalty,
       rivalFactionId: template.rivalFactionId,
       wissen: template.rewardWissenBase,
+      rewardBlueprint: template.rewardBlueprint,
     },
     requiredTier: template.requiredTier,
   };

--- a/packages/server/src/rooms/services/QuestService.ts
+++ b/packages/server/src/rooms/services/QuestService.ts
@@ -40,6 +40,7 @@ import {
   addWissen,
   getQuestById,
   getCargoCapForPlayer,
+  getInventory,
 } from '../../db/queries.js';
 import {
   getCargoState,
@@ -399,6 +400,23 @@ export class QuestService {
       }
       if (rewards.wissen) await addWissen(auth.userId, rewards.wissen);
 
+      // Blueprint reward
+      if (rewards.rewardBlueprint) {
+        const hasBlueprint = await getInventoryItem(auth.userId, 'blueprint', rewards.rewardBlueprint);
+        if (hasBlueprint > 0) {
+          // Player already has this blueprint — give alternative reward (credits + wissen)
+          const altCredits = 200;
+          const altWissen = 15;
+          await addCredits(auth.userId, altCredits);
+          await addWissen(auth.userId, altWissen);
+          this.ctx.send(client, 'creditsUpdate', { credits: await getPlayerCredits(auth.userId) });
+        } else {
+          await addToInventory(auth.userId, 'blueprint', rewards.rewardBlueprint, 1);
+        }
+        const items = await getInventory(auth.userId);
+        this.ctx.send(client, 'inventoryState', { items });
+      }
+
       // Wissen from quest completion, scaled by reward value
       const questWissen = (rewards.credits ?? 0) > 500 ? 10 : 5;
       awardWissenAndNotify(client, auth.userId, questWissen);
@@ -462,6 +480,23 @@ export class QuestService {
           }
         }
         if (rewards.wissen) await addWissen(playerId, rewards.wissen);
+
+        // Blueprint reward
+        if (rewards.rewardBlueprint) {
+          const hasBlueprint = await getInventoryItem(playerId, 'blueprint', rewards.rewardBlueprint);
+          if (hasBlueprint > 0) {
+            const altCredits = 200;
+            const altWissen = 15;
+            await addCredits(playerId, altCredits);
+            await addWissen(playerId, altWissen);
+            this.ctx.send(client, 'creditsUpdate', { credits: await getPlayerCredits(playerId) });
+          } else {
+            await addToInventory(playerId, 'blueprint', rewards.rewardBlueprint, 1);
+          }
+          const items = await getInventory(playerId);
+          this.ctx.send(client, 'inventoryState', { items });
+        }
+
         const questWissen = (rewards.credits ?? 0) > 500 ? 10 : 5;
         awardWissenAndNotify(client, playerId, questWissen);
         this.ctx.send(client, 'questComplete', { id: row.id, title: row.title, rewards });
@@ -695,6 +730,22 @@ export class QuestService {
           }
           if (rewards.wissen) {
             await addWissen(playerId, rewards.wissen);
+          }
+
+          // Blueprint reward
+          if (rewards.rewardBlueprint) {
+            const hasBlueprint = await getInventoryItem(playerId, 'blueprint', rewards.rewardBlueprint);
+            if (hasBlueprint > 0) {
+              const altCredits = 200;
+              const altWissen = 15;
+              await addCredits(playerId, altCredits);
+              await addWissen(playerId, altWissen);
+              this.ctx.send(client, 'creditsUpdate', { credits: await getPlayerCredits(playerId) });
+            } else {
+              await addToInventory(playerId, 'blueprint', rewards.rewardBlueprint, 1);
+            }
+            const items = await getInventory(playerId);
+            this.ctx.send(client, 'inventoryState', { items });
           }
 
           // Wissen from quest completion, scaled by reward value

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -721,6 +721,7 @@ export interface QuestRewards {
   wissen?: number;
   artefactChance?: number;
   blueprintChance?: number;
+  rewardBlueprint?: string;  // moduleId — specific blueprint as quest reward
 }
 
 export interface AvailableQuest {


### PR DESCRIPTION
## Summary
- QuestRewards.rewardBlueprint: optionale moduleId fuer Blueprint-Belohnung
- Quest-Completion: Blueprint ins Inventar, oder 200 CR + 15 Wissen bei Duplikat
- 3 Elite-Quest-Templates mit Blueprints (cargo_mk3, scanner_mk3, shield_mk3)
- Quest-Detail UI zeigt Blueprint in lila
- Alle 3 Completion-Pfade in QuestService abgedeckt

Fixes #406