### PR TITLE
feat: per-faction expansion speed via game_config (#434)

### DIFF
--- a/packages/server/src/engine/gameConfigApply.ts
+++ b/packages/server/src/engine/gameConfigApply.ts
@@ -24,6 +24,7 @@ import {
   CONTENT_WEIGHTS,
   SECTOR_ENVIRONMENT_WEIGHTS,
   CONQUEST_RATE,
+  FACTION_EXPANSION_RATES,
   JUMPGATE_DISTANCE_LIMITS,
   JUMPGATE_CONNECTION_LIMITS,
   JUMPGATE_BUILD_COST,
@@ -153,6 +154,10 @@ export function applyConfigValue(key: string, value: any): void {
   }
   if (key === 'CONQUEST_RATE') {
     deepAssign(CONQUEST_RATE, value);
+    return;
+  }
+  if (key === 'FACTION_EXPANSION_RATES') {
+    Object.assign(FACTION_EXPANSION_RATES, value);
     return;
   }
   if (key === 'JUMPGATE_DISTANCE_LIMITS') {

--- a/packages/server/src/engine/gameConfigSeed.ts
+++ b/packages/server/src/engine/gameConfigSeed.ts
@@ -92,6 +92,7 @@ import {
   CONQUEST_POOL_DRAIN_PER_TICK,
   CONQUEST_POOL_MAX,
   CONQUEST_RATE,
+  FACTION_EXPANSION_RATES,
   JUMPGATE_CHANCE,
   JUMPGATE_FUEL_COST,
   JUMPGATE_TRAVEL_COST_CREDITS,
@@ -304,6 +305,7 @@ const STATIC_SEED: ConfigSeedEntry[] = [
   { key: 'CONQUEST_POOL_DRAIN_PER_TICK', category: 'conquest', description: 'Conquest pool drain per tick', getDefault: () => CONQUEST_POOL_DRAIN_PER_TICK },
   { key: 'CONQUEST_POOL_MAX', category: 'conquest', description: 'Maximum conquest pool', getDefault: () => CONQUEST_POOL_MAX },
   { key: 'CONQUEST_RATE', category: 'conquest', description: 'Conquest rate table by tier', getDefault: () => CONQUEST_RATE },
+  { key: 'FACTION_EXPANSION_RATES', category: 'conquest', description: 'Expansion speed per faction (lower=faster, 10=base, 0=disabled)', getDefault: () => FACTION_EXPANSION_RATES },
 
   // ══════════════════════════════════════════════════════════════════════════════
   // Navigation

--- a/packages/server/src/engine/universeTickEngine.ts
+++ b/packages/server/src/engine/universeTickEngine.ts
@@ -1,11 +1,13 @@
 import {
   UNIVERSE_TICK_MS,
   FACTION_EXPANSION_INTERVAL_TICKS,
+  FACTION_EXPANSION_RATES,
   COSMIC_FACTION_IDS,
   HUMAN_STARTING_TERRITORY,
   ALIEN_STARTING_REGIONS,
   HUMAN_CIVILIZATION_METER_MAX,
 } from '@void-sector/shared';
+import { getConfig } from './gameConfigApply.js';
 import type { CosmicFactionId } from '@void-sector/shared';
 
 export interface TickState {
@@ -128,11 +130,18 @@ export function runUniverseTick(
   let expansionHappened = false;
   const newTerritories: string[] = [];
 
-  // Expansion only happens every FACTION_EXPANSION_INTERVAL_TICKS ticks
-  if (state.tickCount % FACTION_EXPANSION_INTERVAL_TICKS === 0) {
-    // All non-human factions attempt expansion
-    for (const factionId of COSMIC_FACTION_IDS) {
-      if (factionId === 'humans') continue; // humans expand via player activity
+  // Per-faction expansion: each faction has its own rate
+  // Rate from game_config (DB/Redis), fallback to FACTION_EXPANSION_RATES constant
+  const rates = getConfig('FACTION_EXPANSION_RATES') ?? FACTION_EXPANSION_RATES;
+  const baseInterval = FACTION_EXPANSION_INTERVAL_TICKS;
+
+  for (const factionId of COSMIC_FACTION_IDS) {
+    if (factionId === 'humans') continue; // humans expand via player activity
+    const rate = rates[factionId] ?? 10;
+    if (rate <= 0) continue; // rate 0 = no expansion
+    // Scale interval: rate 10 = base interval, rate 5 = half interval (2x faster)
+    const factionInterval = Math.max(1, Math.round(baseInterval * rate / 10));
+    if (state.tickCount % factionInterval === 0) {
       const claimed = expandFaction(factionId, territory, rng);
       if (claimed.length > 0) {
         expansionHappened = true;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2572,7 +2572,22 @@ export function getAcepBoostCost(
 
 // Universe Tick Engine constants
 export const UNIVERSE_TICK_MS = 5_000; // 5 seconds per tick
-export const FACTION_EXPANSION_INTERVAL_TICKS = 360; // 30 min (360 × 5s)
+export const FACTION_EXPANSION_INTERVAL_TICKS = 360; // 30 min (360 × 5s) — base interval, scaled per faction
+
+/** Expansion rate per faction: lower = faster. Base=10 → interval*1.0, rate=5 → interval*0.5 */
+export const FACTION_EXPANSION_RATES: Record<string, number> = {
+  humans: 0,       // humans expand via player activity only
+  kthari: 5,       // aggressive, fast
+  silent_swarm: 4, // very fast swarm invasion
+  archivists: 15,  // slow, conservative
+  consortium: 10,  // normal
+  mycelians: 12,   // slow, organic
+  mirror_minds: 10, // normal, reactive
+  tourist_guild: 20, // very slow, harmless
+  helions: 8,
+  axioms: 10,
+  voids: 6,        // steady expansion
+};
 
 /** Radar render radius for NPC mining drones (hollow circle, px at zoom 2) */
 export const CIV_DRONE_RADIUS = 5;


### PR DESCRIPTION
## Summary
- FACTION_EXPANSION_RATES: pro-Fraktion Geschwindigkeit (DB-konfigurierbar via Admin CONFIG)
- K'thari/Silent Swarm: 2x schneller, Archivare/Touristengilde: 1.5-2x langsamer
- universeTickEngine: individuelles Expansions-Interval pro Fraktion
- Live-Update via Redis Pub/Sub

Fixes #434