### PR TITLE
fix: hyperdrive recharge + diagonal flight + station scrollbar (#455, #457)

### DIFF
--- a/packages/client/src/components/ShipStatusPanel.tsx
+++ b/packages/client/src/components/ShipStatusPanel.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
+import { calculateCurrentCharge } from '@void-sector/shared';
 
 const mono = { fontFamily: 'var(--font-mono)', fontSize: '0.55rem' };
 const dim  = { ...mono, color: 'var(--color-dim)' };
@@ -59,8 +60,19 @@ export function ShipStatusPanel() {
   }
 
   const hasHyperdrive = hyperdriveState && hyperdriveState.maxCharge > 0;
+
+  // Live-update hyperdrive charge via lazy evaluation (regenPerSecond)
+  const [liveCharge, setLiveCharge] = useState(0);
+  useEffect(() => {
+    if (!hasHyperdrive) return;
+    const update = () => setLiveCharge(calculateCurrentCharge(hyperdriveState!, Date.now()));
+    update();
+    const iv = setInterval(update, 1000);
+    return () => clearInterval(iv);
+  }, [hasHyperdrive, hyperdriveState]);
+
   const chargePercent = hasHyperdrive
-    ? Math.round((hyperdriveState!.charge / hyperdriveState!.maxCharge) * 100)
+    ? Math.round((liveCharge / hyperdriveState!.maxCharge) * 100)
     : 0;
 
   return (

--- a/packages/client/src/components/StationTerminalOverlay.tsx
+++ b/packages/client/src/components/StationTerminalOverlay.tsx
@@ -127,7 +127,7 @@ export function StationTerminalOverlay() {
           style={
             {
               flex: 1,
-              overflow: 'auto',
+              overflow: 'hidden',
               '--color-primary': green,
               '--color-dim': dimGreen,
             } as React.CSSProperties

--- a/packages/server/src/rooms/services/NavigationService.ts
+++ b/packages/server/src/rooms/services/NavigationService.ts
@@ -615,24 +615,27 @@ export class NavigationService {
       lastTick: newHdState.lastTick,
     });
 
-    // Build step list (Manhattan path: X first, then Y)
+    // Build step list (diagonal Bresenham path for straight-line flight)
     // Use hyperdriveSpeed for autopilot tick rate
     const autopilotMs =
       ship.hyperdriveSpeed > 0
         ? Math.max(20, Math.floor(AUTOPILOT_STEP_MS / ship.hyperdriveSpeed))
         : AUTOPILOT_STEP_MS;
     const steps: { x: number; y: number }[] = [];
-    let cx = pos.x;
-    let cy = pos.y;
-    const stepX = dx > 0 ? 1 : dx < 0 ? -1 : 0;
-    const stepY = dy > 0 ? 1 : dy < 0 ? -1 : 0;
-    for (let i = 0; i < Math.abs(dx); i++) {
-      cx += stepX;
-      steps.push({ x: cx, y: cy });
-    }
-    for (let i = 0; i < Math.abs(dy); i++) {
-      cy += stepY;
-      steps.push({ x: cx, y: cy });
+    {
+      let cx = pos.x;
+      let cy = pos.y;
+      const adx = Math.abs(dx);
+      const ady = Math.abs(dy);
+      const sx = dx > 0 ? 1 : dx < 0 ? -1 : 0;
+      const sy = dy > 0 ? 1 : dy < 0 ? -1 : 0;
+      let err = adx - ady;
+      while (cx !== targetX || cy !== targetY) {
+        const e2 = 2 * err;
+        if (e2 > -ady) { err -= ady; cx += sx; }
+        if (e2 < adx) { err += adx; cy += sy; }
+        steps.push({ x: cx, y: cy });
+      }
     }
 
     // Start autopilot


### PR DESCRIPTION
## Summary
- **#455 Hyperdrive recharged nicht**: `ShipStatusPanel` zeigte gespeicherten Charge-Wert statt lazy-evaluierten. Jetzt 1s-Intervall mit `calculateCurrentCharge()` für Live-Anzeige
- **#455 Flug ums Eck**: Hyperjump-Pfad von Manhattan (L-Form: erst X, dann Y) auf Bresenham-Diagonal geändert — Schiff fliegt jetzt gerade zum Ziel
- **#457 Scrollbalken auf Station**: StationTerminalOverlay Content-Container `overflow: hidden` statt `auto` — innere Screens (FabrikScreen etc.) scrollen selbst

## Test plan
- [ ] Hyperdrive-Charge steigt nach Jump über Zeit sichtbar an (1s Updates)
- [ ] Hyperjump fliegt diagonal zum Ziel statt L-förmig
- [ ] Station: keine Scrollbalken wenn genug Platz

Closes #455, Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)