### PR TITLE
feat: #452 player visibility on radar with mining pulse + ACEP

### DIFF
--- a/packages/client/src/canvas/RadarRenderer.ts
+++ b/packages/client/src/canvas/RadarRenderer.ts
@@ -660,31 +660,39 @@ export function drawRadar(ctx: CanvasRenderingContext2D, state: RadarState) {
     }
   }
 
-  // Draw other players — zoom >= 2
-  if (state.zoomLevel >= 2) {
+  // Draw other players — visible at all zoom levels
+  {
     const otherPattern = DEFAULT_SHIP_RADAR_PATTERN;
-    const otherPixelSize = 1 + state.zoomLevel;
+    const otherPixelSize = Math.max(2, 1 + state.zoomLevel);
     const otherColor = '#FFDD22';
     const playerList = Object.values(state.players);
-    // Only draw one icon per sector — track which sectors already have an icon
     const drawnSectors = new Set<string>();
+    const now = performance.now();
     for (let i = 0; i < playerList.length; i++) {
       const player = playerList[i];
-      const dx = player.x - viewX;
-      const dy = player.y - viewY;
+      const pdx = player.x - viewX;
+      const pdy = player.y - viewY;
       if (
-        Math.abs(dx) <= radiusX &&
-        Math.abs(dy) <= radiusY &&
+        Math.abs(pdx) <= radiusX &&
+        Math.abs(pdy) <= radiusY &&
         !(player.x === state.position.x && player.y === state.position.y)
       ) {
         const sectorKey = `${player.x}:${player.y}`;
         if (drawnSectors.has(sectorKey)) continue;
         drawnSectors.add(sectorKey);
-        const px = gridCenterX + dx * CELL_W + 12;
-        const py = gridCenterY + dy * CELL_H;
+        const px = gridCenterX + pdx * CELL_W + 12;
+        const py = gridCenterY + pdy * CELL_H;
+
+        // Mining pulse: oscillate alpha when mining
+        if ((player as any).mining) {
+          const pulse = 0.4 + 0.6 * Math.abs(Math.sin(now / 400));
+          ctx.globalAlpha = pulse;
+        }
         drawHullIcon(ctx, otherPattern, px, py, otherColor, otherPixelSize);
-        // Player username at zoom >= 3
-        if (state.zoomLevel >= 3) {
+        ctx.globalAlpha = 1;
+
+        // Player username at zoom >= 2
+        if (state.zoomLevel >= 2) {
           const displayName = player.username?.slice(0, 8) ?? '';
           if (displayName) {
             ctx.font = COORD_FONT;

--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -951,7 +951,10 @@ export function DetailPanel() {
                     fontFamily: 'inherit',
                     fontSize: 'inherit',
                     padding: '2px 0',
-                    display: 'block',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    width: '100%',
                   }}
                   onClick={() => {
                     if (p.userId) {
@@ -961,7 +964,12 @@ export function DetailPanel() {
                     }
                   }}
                 >
-                  ◆ {p.username}
+                  <span>{p.mining ? '⛏' : '◆'} {p.username}</span>
+                  {p.acepTotal > 0 && (
+                    <span style={{ fontSize: '0.55rem', color: 'var(--color-dim)' }}>
+                      ACEP:{p.acepTotal}
+                    </span>
+                  )}
                 </button>
               ))}
             </div>

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -216,6 +216,8 @@ class GameNetwork {
           x: player.x,
           y: player.y,
           connected: player.connected,
+          mining: player.mining ?? false,
+          acepTotal: player.acepTotal ?? 0,
         });
         // Alert if another player enters our sector
         if (player.x === store.position.x && player.y === store.position.y) {
@@ -235,6 +237,8 @@ class GameNetwork {
             x: player.x,
             y: player.y,
             connected: player.connected,
+            mining: player.mining ?? false,
+            acepTotal: player.acepTotal ?? 0,
           });
           // Alert if player moved INTO our sector
           const wasInSector = prev && prev.x === s.position.x && prev.y === s.position.y;

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -265,6 +265,8 @@ export interface PlayerPresence {
   x: number;
   y: number;
   connected: boolean;
+  mining: boolean;
+  acepTotal: number;
 }
 
 export interface BountyEncounterState {

--- a/packages/server/src/__tests__/miningInventory.test.ts
+++ b/packages/server/src/__tests__/miningInventory.test.ts
@@ -94,6 +94,7 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
     _py: vi.fn().mockReturnValue(0),
     getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50 }),
     getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+    state: { players: new Map() },
     ...overrides,
   } as unknown as import('../rooms/services/ServiceContext.js').ServiceContext;
 }

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -1354,6 +1354,24 @@ export class SectorRoom extends Room<SectorRoomState> {
       player.y = sectorY;
       player.connected = true;
 
+      // Set ACEP total XP for player visibility
+      try {
+        const { rows: shipRows } = await query<{ id: string }>(
+          `SELECT id FROM ships WHERE owner_id = $1 AND active = TRUE LIMIT 1`,
+          [auth.userId],
+        );
+        if (shipRows.length > 0) {
+          const acep = await getAcepXpSummary(shipRows[0].id);
+          player.acepTotal = acep.total;
+        }
+      } catch { /* non-critical */ }
+
+      // Set mining state
+      try {
+        const mState = await getMiningState(auth.userId);
+        player.mining = !!(mState?.active);
+      } catch { /* non-critical */ }
+
       this.state.players.set(client.sessionId, player);
       this.state.playerCount = this.state.players.size;
       const allPlayers = Array.from(this.state.players.entries()).map(([sid, p]) => ({

--- a/packages/server/src/rooms/schema/SectorState.ts
+++ b/packages/server/src/rooms/schema/SectorState.ts
@@ -7,6 +7,8 @@ export class PlayerSchema extends Schema {
   x: number = 0;
   y: number = 0;
   connected: boolean = true;
+  mining: boolean = false;
+  acepTotal: number = 0;
 }
 
 defineTypes(PlayerSchema, {
@@ -16,6 +18,8 @@ defineTypes(PlayerSchema, {
   x: 'int32',
   y: 'int32',
   connected: 'boolean',
+  mining: 'boolean',
+  acepTotal: 'uint16',
 });
 
 export class SectorSchema extends Schema {

--- a/packages/server/src/rooms/services/MiningService.ts
+++ b/packages/server/src/rooms/services/MiningService.ts
@@ -275,6 +275,10 @@ export class MiningService {
     await saveMiningState(auth.userId, result.state!);
     client.send('miningUpdate', result.state!);
 
+    // Update player schema mining flag for other players' visibility
+    const playerSchema = this.ctx.state.players.get(client.sessionId);
+    if (playerSchema) playerSchema.mining = true;
+
     // Set auto-stop timer
     const cargoSpace = Math.max(0, ship.cargoCap - cargoTotal);
     this.setAutoStopTimer(
@@ -315,6 +319,10 @@ export class MiningService {
     }
 
     await saveMiningState(auth.userId, result.newState);
+
+    // Update player schema mining flag for other players' visibility
+    const playerSchema = this.ctx.state.players.get(client.sessionId);
+    if (playerSchema) playerSchema.mining = false;
 
     const cargo = await getCargoState(auth.userId);
     client.send('miningUpdate', result.newState);


### PR DESCRIPTION
## Summary
- Andere Spieler sind jetzt auf **allen Zoom-Stufen** sichtbar (vorher nur >= 2)
- **Mining-Spieler pulsieren** auf dem Radar (oszillierende Alpha-Animation)
- **ACEP-XP** wird im Sektor-Detail neben dem Spielernamen angezeigt
- Mining-Spieler zeigen ein Pickel-Icon statt Diamant im Detail
- Spielernamen ab Zoom >= 2 sichtbar (vorher >= 3)
- PlayerSchema um `mining` + `acepTotal` erweitert (Colyseus-Sync)

## Test plan
- [ ] Andere Spieler auf Radar sichtbar bei Zoom 1
- [ ] Spieler pulsiert wenn er mined
- [ ] ACEP-XP im Sektor-Detail sichtbar
- [ ] Bewegung anderer Spieler live sichtbar
- [ ] Spieler-Scan bleibt für andere sichtbar (area scan broadcast)

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)