### PR TITLE
fix: construction sites — BASE view, 1res/sec speed, admin complete (#461 #464 #465)

### DIFF
--- a/packages/client/src/components/BaseOverview.tsx
+++ b/packages/client/src/components/BaseOverview.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
+import { innerCoord } from '@void-sector/shared';
 
 const STRUCTURE_LABELS: Record<string, string> = {
   base: 'COMMAND CENTER',
@@ -24,8 +25,19 @@ const STRUCTURE_ICONS: Record<string, string> = {
   research_lab: '[R]',
 };
 
+const CONSTRUCTION_LABELS: Record<string, string> = {
+  mining_station: 'MINING STATION',
+  jumpgate: 'JUMPGATE',
+  station: 'STATION',
+  jumpgate_conn_2: 'GATE VERBINDUNG L2',
+  jumpgate_conn_3: 'GATE VERBINDUNG L3',
+  jumpgate_dist_2: 'GATE DISTANZ L2',
+  jumpgate_dist_3: 'GATE DISTANZ L3',
+};
+
 export function BaseOverview() {
   const baseStructures = useStore((s) => s.baseStructures);
+  const constructionSites = useStore((s) => s.constructionSites);
   const baseName = useStore((s) => s.baseName);
   const credits = useStore((s) => s.credits);
   const selectedId = useStore((s) => s.selectedBaseStructure);
@@ -38,8 +50,9 @@ export function BaseOverview() {
   }, []);
 
   const hasBase = baseStructures.some((s: any) => s.type === 'base');
+  const hasAnything = hasBase || constructionSites.length > 0;
 
-  if (!hasBase) {
+  if (!hasAnything) {
     return (
       <div
         style={{
@@ -127,6 +140,56 @@ export function BaseOverview() {
           </span>
         </div>
       ))}
+
+      {/* Construction Sites */}
+      {constructionSites.length > 0 && (
+        <>
+          <div
+            style={{
+              fontSize: '0.55rem',
+              letterSpacing: '0.1em',
+              color: 'var(--color-dim)',
+              marginTop: 8,
+              marginBottom: 4,
+            }}
+          >
+            BAUSTELLEN ({constructionSites.length})
+          </div>
+          {constructionSites.map((cs) => {
+            const dur = Math.max(1, cs.neededOre + cs.neededGas + cs.neededCrystal + cs.neededArtefact);
+            const pct = Math.min(100, Math.round((cs.progress / dur) * 100));
+            return (
+              <div
+                key={cs.id}
+                style={{
+                  padding: '4px 6px',
+                  marginBottom: 2,
+                  borderLeft: '2px solid #ffaa00',
+                  background: 'rgba(255,170,0,0.05)',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span>
+                    <span style={{ color: '#ffaa00', marginRight: 4 }}>[B]</span>
+                    <span style={{ color: '#ffaa00' }}>
+                      {CONSTRUCTION_LABELS[cs.type] ?? cs.type.toUpperCase()}
+                    </span>
+                  </span>
+                  <span style={{ opacity: 0.6, fontSize: '0.55rem', color: cs.paused ? '#ff4444' : '#ffaa00' }}>
+                    {cs.paused ? 'PAUSIERT' : `${pct}%`}
+                  </span>
+                </div>
+                <div style={{ fontSize: '0.5rem', color: 'var(--color-dim)' }}>
+                  ({innerCoord(cs.sectorX)}, {innerCoord(cs.sectorY)})
+                </div>
+                <div style={{ height: 2, background: 'rgba(255,255,255,0.08)', marginTop: 2 }}>
+                  <div style={{ height: '100%', width: `${pct}%`, background: '#ffaa00' }} />
+                </div>
+              </div>
+            );
+          })}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/DetailPanel.tsx
+++ b/packages/client/src/components/DetailPanel.tsx
@@ -163,7 +163,8 @@ function ConstructionSitePanel({ site }: { site: ConstructionSiteState }) {
   const maxCredits  = Math.min(playerCredits,       remainCredits);
   const maxArtefact = Math.min(cargo.artefact ?? 0, remainArtefact);
 
-  const pct = site.progress;
+  const duration = Math.max(1, site.neededOre + site.neededGas + site.neededCrystal + site.neededArtefact);
+  const pctValue = Math.min(100, Math.round((site.progress / duration) * 100));
   const canDeliver = amounts.ore + amounts.gas + amounts.crystal + amounts.credits + amounts.artefact > 0;
   const adminToken = localStorage.getItem('vs_admin_token');
 
@@ -218,10 +219,10 @@ function ConstructionSitePanel({ site }: { site: ConstructionSiteState }) {
 
       {/* Progress bar */}
       <div style={{ height: 4, background: 'rgba(255,255,255,0.1)', marginBottom: 2 }}>
-        <div style={{ height: '100%', width: `${pct}%`, background: 'var(--color-primary)', transition: 'width 0.5s' }} />
+        <div style={{ height: '100%', width: `${pctValue}%`, background: 'var(--color-primary)', transition: 'width 0.5s' }} />
       </div>
       <div style={{ fontSize: '0.6rem', color: 'var(--color-dim)', marginBottom: 6 }}>
-        {pct}/100 Ticks
+        {site.progress}/{duration}s ({pctValue}%)
       </div>
 
       {/* Resource status */}

--- a/packages/server/src/__tests__/miningRate.test.ts
+++ b/packages/server/src/__tests__/miningRate.test.ts
@@ -47,6 +47,7 @@ describe('MiningService mining rate includes miningBonus', () => {
       _pst: vi.fn().mockReturnValue('asteroid_field'),
       getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0.5 }),
       getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+      state: { players: new Map() },
     } as any;
 
     const svc = new MiningService(ctx);
@@ -68,6 +69,7 @@ describe('MiningService mining rate includes miningBonus', () => {
       _pst: vi.fn().mockReturnValue('asteroid_field'),
       getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0 }),
       getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+      state: { players: new Map() },
     } as any;
 
     const svc = new MiningService(ctx);
@@ -89,6 +91,7 @@ describe('MiningService mining rate includes miningBonus', () => {
       _pst: vi.fn().mockReturnValue('asteroid_field'),
       getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0 }),
       getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+      state: { players: new Map() },
     } as any;
 
     const svc = new MiningService(ctx);
@@ -112,6 +115,7 @@ describe('MiningService mining rate includes miningBonus', () => {
       _pst: vi.fn().mockReturnValue('asteroid_field'),
       getShipForClient: vi.fn().mockReturnValue({ cargoCap: 50, miningBonus: 0.5 }),
       getPlayerBonuses: vi.fn().mockResolvedValue({ miningRateMultiplier: 1 }),
+      state: { players: new Map() },
     } as any;
 
     const svc = new MiningService(ctx);

--- a/packages/server/src/adminRoutes.ts
+++ b/packages/server/src/adminRoutes.ts
@@ -49,6 +49,7 @@ import {
 import { query } from './db/client.js';
 import { civQueries } from './db/civQueries.js';
 import { constructionBus } from './constructionBus.js';
+import { completeConstruction as completeConstructionFn } from './engine/constructionTickService.js';
 import { MODULES, QUADRANT_SIZE } from '@void-sector/shared';
 import { STORY_CHAPTERS } from './engine/storyQuestChain.js';
 import { getStoryProgress, upsertStoryProgress } from './db/queries.js';
@@ -604,11 +605,10 @@ adminRouter.post('/construction-sites/:id/complete', async (req: Request, res: R
       return;
     }
     try {
-      await createStructure(site.owner_id, site.type, site.sector_x, site.sector_y);
+      await completeConstructionFn(site);
       await deleteConstructionSiteById(site.id);
     } catch (err: any) {
       if (err.code !== '23505') throw err;
-      // Duplicate structure — delete site anyway and treat as success
       await deleteConstructionSiteById(site.id);
     }
     await logAdminEvent('complete_construction', { siteId: site.id, type: site.type, sectorX: site.sector_x, sectorY: site.sector_y });
@@ -616,6 +616,9 @@ adminRouter.post('/construction-sites/:id/complete', async (req: Request, res: R
       siteId: site.id,
       sectorX: site.sector_x,
       sectorY: site.sector_y,
+      type: site.type,
+      ownerId: site.owner_id,
+      metadata: site.metadata,
     });
     logger.info({ id, type: site.type }, 'Admin completed construction site');
     res.json({ success: true });

--- a/packages/server/src/engine/__tests__/constructionTick.test.ts
+++ b/packages/server/src/engine/__tests__/constructionTick.test.ts
@@ -28,6 +28,7 @@ import {
 import { createStructure } from '../../db/queries.js';
 import { constructionBus } from '../../constructionBus.js';
 
+// duration = ore(30) + gas(15) + crystal(10) + artefact(0) = 55
 const baseSite = {
   id: 'site-1',
   owner_id: 'player-1',
@@ -57,6 +58,7 @@ describe('processConstructionTick', () => {
   });
 
   it('advances when resources meet threshold at progress 0→1', async () => {
+    // duration=55, at progress 1: need ceil(1*30/55)=1 ore, ceil(1*15/55)=1 gas, ceil(1*10/55)=1 crystal
     (getAllConstructionSites as any).mockResolvedValue([{
       ...baseSite, progress: 0,
       deposited_ore: 1, deposited_gas: 1, deposited_crystal: 1,
@@ -69,7 +71,7 @@ describe('processConstructionTick', () => {
 
   it('pauses when insufficient resources', async () => {
     (getAllConstructionSites as any).mockResolvedValue([{
-      ...baseSite, progress: 50,
+      ...baseSite, progress: 25,
       deposited_ore: 0, deposited_gas: 0, deposited_crystal: 0,
     }]);
     await processConstructionTick();
@@ -79,16 +81,17 @@ describe('processConstructionTick', () => {
 
   it('does not re-pause an already-paused site', async () => {
     (getAllConstructionSites as any).mockResolvedValue([{
-      ...baseSite, progress: 50, paused: true,
+      ...baseSite, progress: 25, paused: true,
       deposited_ore: 0, deposited_gas: 0, deposited_crystal: 0,
     }]);
     await processConstructionTick();
     expect(markPaused).not.toHaveBeenCalled();
   });
 
-  it('creates structure and deletes site when progress reaches 100', async () => {
+  it('creates structure and deletes site when progress reaches duration (55)', async () => {
+    // duration=55, progress 54→55 = complete
     (getAllConstructionSites as any).mockResolvedValue([{
-      ...baseSite, progress: 99,
+      ...baseSite, progress: 54,
       deposited_ore: 30, deposited_gas: 15, deposited_crystal: 10,
     }]);
     (createStructure as any).mockResolvedValue({ id: 'struct-1' });

--- a/packages/server/src/engine/constructionTickService.ts
+++ b/packages/server/src/engine/constructionTickService.ts
@@ -10,8 +10,24 @@ import { sectorToQuadrant } from './quadrantEngine.js';
 import { logger } from '../utils/logger.js';
 import { constructionBus } from '../constructionBus.js';
 
-function resourcesNeededAt(progress: number, total: number): number {
-  return Math.ceil((progress * total) / 100);
+/**
+ * Construction duration = sum of non-credit resources (ore + gas + crystal + artefact).
+ * 1 tick = 1 second = 1 resource unit consumed.
+ * Credits are consumed proportionally alongside material resources.
+ */
+function getTotalDuration(site: {
+  needed_ore: number;
+  needed_gas: number;
+  needed_crystal: number;
+  needed_artefact: number;
+}): number {
+  const material = site.needed_ore + site.needed_gas + site.needed_crystal + site.needed_artefact;
+  return Math.max(1, material);
+}
+
+function resourcesNeededAt(progress: number, total: number, duration: number): number {
+  if (total === 0) return 0;
+  return Math.ceil((progress * total) / duration);
 }
 
 export async function processConstructionTick(): Promise<void> {
@@ -19,12 +35,14 @@ export async function processConstructionTick(): Promise<void> {
   if (sites.length === 0) return;
 
   for (const site of sites) {
+    const duration = getTotalDuration(site);
     const nextProgress = site.progress + 1;
-    const oreNeeded      = resourcesNeededAt(nextProgress, site.needed_ore);
-    const gasNeeded      = resourcesNeededAt(nextProgress, site.needed_gas);
-    const crystalNeeded  = resourcesNeededAt(nextProgress, site.needed_crystal);
-    const creditsNeeded  = resourcesNeededAt(nextProgress, site.needed_credits);
-    const artefactNeeded = resourcesNeededAt(nextProgress, site.needed_artefact);
+
+    const oreNeeded      = resourcesNeededAt(nextProgress, site.needed_ore, duration);
+    const gasNeeded      = resourcesNeededAt(nextProgress, site.needed_gas, duration);
+    const crystalNeeded  = resourcesNeededAt(nextProgress, site.needed_crystal, duration);
+    const creditsNeeded  = resourcesNeededAt(nextProgress, site.needed_credits, duration);
+    const artefactNeeded = resourcesNeededAt(nextProgress, site.needed_artefact, duration);
 
     const hasResources =
       site.deposited_ore      >= oreNeeded &&
@@ -38,7 +56,7 @@ export async function processConstructionTick(): Promise<void> {
       continue;
     }
 
-    if (nextProgress >= 100) {
+    if (nextProgress >= duration) {
       try {
         await completeConstruction(site);
         await deleteConstructionSiteById(site.id);
@@ -69,7 +87,7 @@ export async function processConstructionTick(): Promise<void> {
   }
 }
 
-async function completeConstruction(site: {
+export async function completeConstruction(site: {
   owner_id: string;
   type: string;
   sector_x: number;


### PR DESCRIPTION
## Summary
- **#461**: Baustellen erscheinen jetzt im BASE-Programm mit Fortschrittsbalken, Typ und Koordinaten
- **#464**: Baudauer = Summe Materialressourcen (ore+gas+crystal+artefact) in Sekunden statt fixer 100 Ticks
- **#465**: Admin-Vervollständigung nutzt `completeConstruction()` — Jumpgates/Stations/Upgrades werden korrekt erstellt

## Test plan
- [ ] BASE-Programm zeigt aktive Baustellen mit Fortschritt
- [ ] Baustelle mit 50 ore + 20 crystal + 5 artefact dauert 75 Sekunden
- [ ] Admin "SOFORT VOLLENDEN" erstellt das korrekte Bauwerk (Jumpgate/Station)
- [ ] Fortschrittsbalken zeigt progress/duration statt /100

Closes #461, Closes #464, Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)