### PR TITLE
feat: floating feedback button → admin console

### DIFF
--- a/docs/superpowers/specs/2026-05-29-feedback-button-design.md
+++ b/docs/superpowers/specs/2026-05-29-feedback-button-design.md
@@ -1,0 +1,79 @@
+# Feedback Button — Design
+
+**Date:** 2026-05-29 · **Status:** approved (design)
+
+## Goal
+
+A floating "FEEDBACK" button in the running app lets logged-in players send feedback (a message + a category). Submitted feedback lands in the admin console as a new "FEEDBACK" tab where it can be read and marked new/done. Mirrors the existing "stories" admin feature end-to-end.
+
+## Decisions (locked with user)
+
+- **Content:** free-text `message` + `category` ∈ {bug, idea, praise, other}.
+- **Access:** logged-in users only — guests do not see the button and cannot submit (the submit endpoint requires a valid player token).
+- **Admin:** list newest-first; per entry toggle status new ↔ done.
+- **Out of scope (YAGNI):** rate limiting (logged-in-only ⇒ low risk), screenshots/attachments, email notification, editing/replying to feedback.
+
+## Architecture
+
+Reuses the proven "stories" pattern: dedicated DB table → query module → REST endpoints → admin-console tab → client overlay mounted alongside `HelpOverlay`.
+
+### Database — migration `085_feedback.sql`
+```sql
+CREATE TABLE IF NOT EXISTS feedback (
+  id SERIAL PRIMARY KEY,
+  player_id UUID,                                  -- from token; nullable defensively
+  username VARCHAR(64),
+  category VARCHAR(16) NOT NULL DEFAULT 'other',   -- bug | idea | praise | other
+  message  TEXT NOT NULL,
+  status   VARCHAR(16) NOT NULL DEFAULT 'new',     -- new | done
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_feedback_status_created ON feedback(status, created_at DESC);
+```
+(All migrations are idempotent and auto-run on startup. 085 is the next number after 084.)
+
+### Server
+- **Queries** (`packages/server/src/db/feedbackQueries.ts`):
+  - `createFeedback({ playerId, username, category, message }): Promise<number>` — INSERT, RETURNING id.
+  - `getFeedback(limit = 100): Promise<FeedbackRow[]>` — SELECT ordered `created_at DESC`.
+  - `setFeedbackStatus(id, status): Promise<void>` — UPDATE status.
+- **Validation helper** (pure, unit-tested): `validateFeedbackInput(body): { category, message } | { error }` — category must be in the allowed set (default `other` if missing), message required and trimmed length 1..2000.
+- **Submit endpoint** — public Express route in `app.config.ts` `initializeExpress` (sibling of `/api/register`): `POST /api/feedback`.
+  - Requires `Authorization: Bearer <playerToken>`; verifies via `verifyToken` (same helper `SectorRoom.onAuth` uses). Missing/invalid → 401. This enforces "logged-in only". `player_id`/`username` come from the verified payload.
+  - Body `{ category, message }` validated by the helper; invalid → 400. Insert → 201 `{ id }`.
+- **Admin list** — `GET /admin/api/feedback?limit=100` under `adminRouter` (Bearer `ADMIN_TOKEN`) → `{ feedback: [...] }`.
+- **Admin status** — `PATCH /admin/api/feedback/:id` body `{ status }` under `adminRouter`; validates status ∈ {new, done}; calls `setFeedbackStatus` + `logAdminEvent('set_feedback_status', { id, status })`.
+
+### Admin console (`packages/server/src/admin/console.html`)
+- Add `<div class="tab" data-tab="feedback">FEEDBACK</div>` to the tab bar.
+- Add `<div class="tab-panel" id="panel-feedback">` with an empty-state + list container (mirror the stories panel).
+- Add `else if (name === 'feedback') loadFeedback();` to `switchTab()`.
+- `loadFeedback()` (mirror `loadStories()`): `api('GET','/feedback?limit=100')`, render each entry as a card — category badge, username, message, formatted date, and a button to toggle status (calls `api('PATCH','/feedback/'+id, { status })` then reloads). Done entries visually dimmed.
+
+### Client
+- **`FeedbackButton.tsx`** — floating FAB: `position:fixed; bottom:16px; right:16px; z-index:9000`, CRT-amber (`var(--color-primary)`/`--color-dim`, `var(--font-mono)`), label `FEEDBACK`. Rendered only when `token && !isGuest` (reads store). Click → opens the modal (local `open` state, or a small `uiSlice`/local state).
+- **`FeedbackModal.tsx`** (can live in the same file) — overlay (fixed, dim backdrop, CRT box): category select (Bug/Idee/Lob/Sonstiges), `<textarea>` for the message, `[SENDEN]` (disabled when message is empty/whitespace) and `[ABBRECHEN]`. Header shows a `[?]` button → `showTip('first_feedback')`.
+  - Submit → `fetch(`${import.meta.env.VITE_API_URL || ''}/api/feedback`, { method:'POST', headers:{ 'Content-Type':'application/json', Authorization:`Bearer ${token}` }, body: JSON.stringify({ category, message }) })`.
+  - Success → close, clear, `addLogEntry('Danke für dein Feedback!')` (toast/log). Failure → inline error text in the modal.
+- **Mount** `<FeedbackButton />` in `GameScreen.tsx` alongside `<HelpOverlay />`.
+- **HelpSlice** `first_feedback` (CLAUDE.md onboarding rule): German, ≤6 lines — what the button does and the categories. Shown on first modal open; re-openable via the modal-header `[?]`.
+
+### Data flow
+Click FAB → modal → submit → `POST /api/feedback` (player-token auth) → INSERT → 201 → modal closes with thanks. Admin opens console → FEEDBACK tab → `GET /admin/api/feedback` → list → toggle status → `PATCH /admin/api/feedback/:id`.
+
+## Components (isolation)
+- `validateFeedbackInput` — pure, no IO, unit-tested directly (category whitelist + message length).
+- `feedbackQueries` — thin DB layer, mirrors `adminQueries` story functions.
+- `FeedbackButton`/`FeedbackModal` — presentation + one fetch; no business logic beyond enabling submit.
+
+## Testing
+- **Server unit:** `validateFeedbackInput` — accepts valid, defaults missing category to `other`, rejects empty/oversized message, rejects unknown category.
+- **Client unit (RTL + `vi.mock` fetch):**
+  - Button hidden when `isGuest` true / no token; visible when `token && !isGuest`.
+  - Opening the modal renders category select + textarea; `[SENDEN]` disabled on empty message.
+  - Submit posts to `/api/feedback` with `Authorization: Bearer <token>` and `{ category, message }`; success closes the modal.
+- **Manual/E2E:** submit from the app → entry appears in admin FEEDBACK tab → toggle new/done persists.
+
+## Risks
+- Guest exclusion is enforced client-side (button hidden) + server-side by requiring a valid token; if guest tokens are indistinguishable from user tokens server-side, the practical control is the UI gate (acceptable for low-stakes feedback). Verify whether the JWT payload carries a guest flag during implementation; enforce server-side if available.
+- New 15th-ish program is unaffected; the FAB is an overlay, not a cockpit program, so it does not touch the 6-section/mobile layout.

--- a/packages/client/src/__tests__/FeedbackButton.test.tsx
+++ b/packages/client/src/__tests__/FeedbackButton.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedbackButton } from '../components/FeedbackButton';
+import { mockStoreState } from '../test/mockStore';
+
+describe('FeedbackButton', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is hidden for guests', () => {
+    mockStoreState({ token: 'tok', isGuest: true } as any);
+    render(<FeedbackButton />);
+    expect(screen.queryByTestId('feedback-fab')).toBeNull();
+  });
+
+  it('is hidden when not logged in', () => {
+    mockStoreState({ token: null, isGuest: false } as any);
+    render(<FeedbackButton />);
+    expect(screen.queryByTestId('feedback-fab')).toBeNull();
+  });
+
+  it('shows for a logged-in non-guest and opens the modal (send disabled while empty)', async () => {
+    mockStoreState({ token: 'tok', isGuest: false } as any);
+    render(<FeedbackButton />);
+    const fab = screen.getByTestId('feedback-fab');
+    expect(fab).toBeInTheDocument();
+    await userEvent.click(fab);
+    expect(screen.getByTestId('feedback-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('feedback-send')).toBeDisabled();
+  });
+
+  it('submits with auth header + payload and closes', async () => {
+    mockStoreState({ token: 'tok123', isGuest: false } as any);
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ ok: true, status: 201, json: async () => ({ id: 1 }) } as Response);
+    render(<FeedbackButton />);
+    await userEvent.click(screen.getByTestId('feedback-fab'));
+    await userEvent.selectOptions(screen.getByTestId('feedback-category'), 'bug');
+    await userEvent.type(screen.getByTestId('feedback-message'), 'Es ruckelt');
+    await userEvent.click(screen.getByTestId('feedback-send'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/api/feedback');
+    expect(opts.method).toBe('POST');
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer tok123');
+    expect(JSON.parse(opts.body as string)).toEqual({ category: 'bug', message: 'Es ruckelt' });
+    await waitFor(() => expect(screen.queryByTestId('feedback-modal')).toBeNull());
+  });
+});

--- a/packages/client/src/components/FeedbackButton.tsx
+++ b/packages/client/src/components/FeedbackButton.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import { useStore } from '../state/store';
+
+const CATEGORIES: { value: string; label: string }[] = [
+  { value: 'bug', label: 'Bug' },
+  { value: 'idea', label: 'Idee' },
+  { value: 'praise', label: 'Lob' },
+  { value: 'other', label: 'Sonstiges' },
+];
+
+export function FeedbackButton() {
+  const token = useStore((s) => s.token);
+  const isGuest = useStore((s) => s.isGuest);
+  const addLogEntry = useStore((s) => s.addLogEntry);
+  const showTip = useStore((s) => s.showTip);
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('idea');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+
+  if (!token || isGuest) return null;
+
+  function openModal() {
+    setError(null);
+    setOpen(true);
+    showTip('first_feedback');
+  }
+
+  async function submit() {
+    const trimmed = message.trim();
+    if (!trimmed || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      const API_URL = import.meta.env.VITE_API_URL || '';
+      const res = await fetch(`${API_URL}/api/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ category, message: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data as { error?: string }).error || `Fehler ${res.status}`);
+      }
+      addLogEntry('Danke für dein Feedback!');
+      setMessage('');
+      setOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Senden fehlgeschlagen');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        data-testid="feedback-fab"
+        onClick={openModal}
+        title="Feedback geben"
+        style={{
+          position: 'fixed',
+          bottom: 16,
+          right: 16,
+          zIndex: 9000,
+          background: '#0a0a0a',
+          border: '1px solid var(--color-primary)',
+          color: 'var(--color-primary)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: '0.7rem',
+          letterSpacing: '0.1em',
+          padding: '6px 10px',
+          cursor: 'pointer',
+        }}
+      >
+        FEEDBACK
+      </button>
+      {open && (
+        <div
+          data-testid="feedback-modal"
+          onClick={() => setOpen(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 9001,
+            background: 'rgba(0,0,0,0.6)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: '#0a0a0a',
+              border: '1px solid var(--color-primary)',
+              padding: 16,
+              width: 'min(420px, 90vw)',
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--color-primary)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+              <span style={{ fontSize: '0.8rem', letterSpacing: '0.2em', flex: 1 }}>FEEDBACK</span>
+              <button
+                onClick={() => showTip('first_feedback')}
+                title="Hilfe"
+                style={{
+                  background: 'none',
+                  border: '1px solid var(--color-dim)',
+                  color: 'var(--color-dim)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.65rem',
+                  padding: '0 4px',
+                  cursor: 'pointer',
+                }}
+              >
+                [?]
+              </button>
+            </div>
+            <select
+              data-testid="feedback-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              style={{
+                width: '100%',
+                marginBottom: 8,
+                background: '#0d0d0d',
+                color: 'var(--color-primary)',
+                border: '1px solid var(--color-dim)',
+                fontFamily: 'var(--font-mono)',
+                padding: 4,
+              }}
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <textarea
+              data-testid="feedback-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={5}
+              maxLength={2000}
+              placeholder="Dein Feedback…"
+              style={{
+                width: '100%',
+                boxSizing: 'border-box',
+                background: '#0d0d0d',
+                color: 'var(--color-primary)',
+                border: '1px solid var(--color-dim)',
+                fontFamily: 'var(--font-mono)',
+                padding: 4,
+                resize: 'vertical',
+              }}
+            />
+            {error && (
+              <div style={{ color: '#FF4444', fontSize: '0.75rem', marginTop: 4 }}>⚠ {error}</div>
+            )}
+            <div style={{ display: 'flex', gap: 8, marginTop: 10, justifyContent: 'flex-end' }}>
+              <button className="vs-btn" onClick={() => setOpen(false)}>
+                [ABBRECHEN]
+              </button>
+              <button
+                className="vs-btn"
+                data-testid="feedback-send"
+                disabled={!message.trim() || sending}
+                onClick={submit}
+              >
+                {sending ? '…' : '[SENDEN]'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/components/GameScreen.tsx
+++ b/packages/client/src/components/GameScreen.tsx
@@ -17,6 +17,7 @@ import { AcepProgram } from './AcepProgram';
 import { FriendsScreen } from './FriendsScreen';
 import { FabrikPanel } from './FabrikPanel';
 import { XenoScreen } from './XenoScreen';
+import { FeedbackButton } from './FeedbackButton';
 import { HelpOverlay } from './HelpOverlay';
 import { AncientRuinDialog } from './AncientRuinDialog';
 import { CompendiumOverlay } from './CompendiumOverlay';
@@ -482,6 +483,7 @@ export function GameScreen() {
       <BlueprintDialog />
       <CompendiumOverlay />
       <HelpOverlay />
+      <FeedbackButton />
       <AncientRuinDialog />
       <StationTerminalGate />
     </div>

--- a/packages/client/src/state/helpSlice.ts
+++ b/packages/client/src/state/helpSlice.ts
@@ -26,6 +26,15 @@ export const HELP_TIPS: HelpTip[] = [
       '→ Dein Ruf bestimmt, was eine Fraktion dir anbietet',
   },
   {
+    id: 'first_feedback',
+    title: '◈ FEEDBACK',
+    body:
+      'Sag uns, was du denkst!\n\n' +
+      '→ Kategorie wählen: Bug, Idee, Lob oder Sonstiges\n' +
+      '→ Nachricht schreiben und [SENDEN]\n' +
+      '→ Dein Feedback landet direkt beim Admin-Team',
+  },
+  {
     id: 'first_nebula',
     title: 'NEBULA-SEKTOR',
     body: 'Nebula-Sektoren enthalten Gas-Ressourcen. Scanne den Sektor zuerst um Ressourcen zu sehen. Gas kann an Handelsstationen verkauft werden.',

--- a/packages/client/src/test/mockStore.ts
+++ b/packages/client/src/test/mockStore.ts
@@ -126,6 +126,7 @@ export function mockStoreState(overrides: Partial<StoreState> = {}) {
     showTip: vi.fn(),
     dismissTip: vi.fn(),
     hasSeenTip: vi.fn(),
+    addLogEntry: vi.fn(),
     onboardingStep: null,
     advanceOnboarding: vi.fn(),
     skipOnboarding: vi.fn(),

--- a/packages/server/src/__tests__/feedbackValidation.test.ts
+++ b/packages/server/src/__tests__/feedbackValidation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { validateFeedbackInput } from '../feedbackValidation.js';
+
+describe('validateFeedbackInput', () => {
+  it('accepts a valid message + category', () => {
+    expect(validateFeedbackInput({ category: 'bug', message: 'kaputt' })).toEqual({
+      category: 'bug',
+      message: 'kaputt',
+    });
+  });
+
+  it('trims the message', () => {
+    expect(validateFeedbackInput({ category: 'idea', message: '  hallo  ' })).toEqual({
+      category: 'idea',
+      message: 'hallo',
+    });
+  });
+
+  it('defaults a missing category to other', () => {
+    expect(validateFeedbackInput({ message: 'x' })).toEqual({ category: 'other', message: 'x' });
+  });
+
+  it('falls back an unknown category to other', () => {
+    expect(validateFeedbackInput({ category: 'nope', message: 'x' })).toEqual({
+      category: 'other',
+      message: 'x',
+    });
+  });
+
+  it('rejects an empty/whitespace message', () => {
+    expect('error' in validateFeedbackInput({ category: 'bug', message: '   ' })).toBe(true);
+    expect('error' in validateFeedbackInput({ category: 'bug' })).toBe(true);
+  });
+
+  it('rejects an oversized message (>2000)', () => {
+    expect('error' in validateFeedbackInput({ message: 'a'.repeat(2001) })).toBe(true);
+  });
+});

--- a/packages/server/src/admin/console.html
+++ b/packages/server/src/admin/console.html
@@ -2147,6 +2147,7 @@ expiresDays: 14"></textarea>
 
   // ── STORIES ─────────────────────────────────────────────────────
 
+  // ── FEEDBACK ────────────────────────────────────────────────
   function loadFeedback() {
     api('GET', '/feedback?limit=100').then(function (data) {
       var items = data.feedback || [];

--- a/packages/server/src/admin/console.html
+++ b/packages/server/src/admin/console.html
@@ -571,6 +571,7 @@ button.success:hover {
     <div class="tab" data-tab="errors">ERRORS <span id="errors-badge" style="display:none;background:#ff4444;color:#fff;border-radius:10px;padding:0 5px;font-size:10px;margin-left:4px;vertical-align:middle"></span></div>
     <div class="tab" data-tab="config">CONFIG</div>
     <div class="tab" data-tab="drones">DROHNEN</div>
+    <div class="tab" data-tab="feedback">FEEDBACK</div>
   </div>
 
   <div id="content">
@@ -857,6 +858,16 @@ expiresDays: 14"></textarea>
       </div>
       <div id="stories-empty" class="empty-state" style="display:none">No stories yet. Run /playtest to create one.</div>
       <div id="stories-list" style="display:flex;flex-direction:column;gap:16px;overflow:auto;max-height:calc(100vh - 200px);padding-right:8px"></div>
+    </div>
+
+    <!-- ── FEEDBACK Tab ─────────────────────────────────────────── -->
+    <div class="tab-panel" id="panel-feedback">
+      <div class="section-title">Feedback</div>
+      <div style="color:var(--amber-dim);font-size:11px;margin-bottom:16px;letter-spacing:0.5px">
+        Spieler-Feedback aus dem schwebenden FEEDBACK-Button
+      </div>
+      <div id="feedback-empty" class="empty-state" style="display:none">Noch kein Feedback.</div>
+      <div id="feedback-list" style="display:flex;flex-direction:column;gap:12px;overflow:auto;max-height:calc(100vh - 200px);padding-right:8px"></div>
     </div>
 
     <!-- ── QUAD-MAP Tab ─────────────────────────────────────────── -->
@@ -1258,6 +1269,7 @@ expiresDays: 14"></textarea>
     }
     else if (name === 'errors') loadErrors('new');
     else if (name === 'config') loadConfig();
+    else if (name === 'feedback') loadFeedback();
   }
 
   function switchQuestSubTab(name) {
@@ -2134,6 +2146,52 @@ expiresDays: 14"></textarea>
   }
 
   // ── STORIES ─────────────────────────────────────────────────────
+
+  function loadFeedback() {
+    api('GET', '/feedback?limit=100').then(function (data) {
+      var items = data.feedback || [];
+      var container = document.getElementById('feedback-list');
+      var empty = document.getElementById('feedback-empty');
+      clearChildren(container);
+      if (items.length === 0) { empty.style.display = 'block'; return; }
+      empty.style.display = 'none';
+      items.forEach(function (fb) {
+        var done = fb.status === 'done';
+        var card = el('div', { className: 'card' });
+        card.style.opacity = done ? '0.5' : '1';
+
+        var head = el('div');
+        var cat = el('strong');
+        cat.textContent = '[' + fb.category + '] ';
+        var who = document.createTextNode((fb.username || 'anonym') + ' ');
+        var when = el('small');
+        when.textContent = formatDate(fb.createdAt || fb.created_at);
+        head.appendChild(cat); head.appendChild(who); head.appendChild(when);
+
+        // textContent (not innerHTML) — message is untrusted user input
+        var msg = el('div');
+        msg.style.margin = '6px 0';
+        msg.style.whiteSpace = 'pre-wrap';
+        msg.textContent = fb.message;
+
+        var btn = el('button');
+        btn.style.cssText = 'margin-top:8px;background:#0d0d0d;border:1px solid var(--amber-dim);color:var(--amber);font-family:var(--font);font-size:11px;padding:4px 8px;cursor:pointer';
+        btn.textContent = done ? 'als NEU markieren' : 'als ERLEDIGT markieren';
+        btn.onclick = function () {
+          api('PATCH', '/feedback/' + fb.id, { status: done ? 'new' : 'done' })
+            .then(loadFeedback)
+            .catch(function (err) { toast('Status-Update fehlgeschlagen: ' + err.message, 'error'); });
+        };
+
+        card.appendChild(head);
+        card.appendChild(msg);
+        card.appendChild(btn);
+        container.appendChild(card);
+      });
+    }).catch(function (err) {
+      toast('Feedback laden fehlgeschlagen: ' + err.message, 'error');
+    });
+  }
 
   function loadStories() {
     api('GET', '/stories').then(function(data) {

--- a/packages/server/src/adminRoutes.ts
+++ b/packages/server/src/adminRoutes.ts
@@ -28,6 +28,7 @@ import {
   deleteErrorLog,
 } from './db/adminQueries.js';
 import type { AdminQuestInput, AdminMessageInput, AdminStoryInput } from './db/adminQueries.js';
+import { getFeedback, setFeedbackStatus } from './db/feedbackQueries.js';
 import type { AdminPlayerUpdateEvent } from './adminBus.js';
 import { getPlayerPosition, savePlayerPosition } from './rooms/services/RedisAPStore.js';
 import { adminBus } from './adminBus.js';
@@ -565,6 +566,35 @@ adminRouter.get('/stories/:id', async (req: Request, res: Response) => {
     res.json({ story });
   } catch (err) {
     logger.error({ err }, 'Admin get story error');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Feedback ─────────────────────────────────────────────────────────
+adminRouter.get('/feedback', async (req: Request, res: Response) => {
+  try {
+    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
+    const feedback = await getFeedback(limit);
+    res.json({ feedback });
+  } catch (err) {
+    logger.error({ err }, 'Admin list feedback error');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+adminRouter.patch('/feedback/:id', async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id as string, 10);
+    const status = (req.body as { status?: string }).status;
+    if (status !== 'new' && status !== 'done') {
+      res.status(400).json({ error: 'status must be new or done' });
+      return;
+    }
+    await setFeedbackStatus(id, status);
+    await logAdminEvent('set_feedback_status', { id, status });
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, 'Admin set feedback status error');
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/packages/server/src/adminRoutes.ts
+++ b/packages/server/src/adminRoutes.ts
@@ -573,7 +573,7 @@ adminRouter.get('/stories/:id', async (req: Request, res: Response) => {
 // ── Feedback ─────────────────────────────────────────────────────────
 adminRouter.get('/feedback', async (req: Request, res: Response) => {
   try {
-    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
+    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) || 100 : 100;
     const feedback = await getFeedback(limit);
     res.json({ feedback });
   } catch (err) {
@@ -585,6 +585,10 @@ adminRouter.get('/feedback', async (req: Request, res: Response) => {
 adminRouter.patch('/feedback/:id', async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) {
+      res.status(400).json({ error: 'Invalid id' });
+      return;
+    }
     const status = (req.body as { status?: string }).status;
     if (status !== 'new' && status !== 'done') {
       res.status(400).json({ error: 'status must be new or done' });

--- a/packages/server/src/app.config.ts
+++ b/packages/server/src/app.config.ts
@@ -7,7 +7,9 @@ import type { Server } from '@colyseus/core';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { SectorRoom } from './rooms/SectorRoom.js';
-import { register, login, loginAsGuest } from './auth.js';
+import { register, login, loginAsGuest, verifyToken, type AuthPayload } from './auth.js';
+import { validateFeedbackInput } from './feedbackValidation.js';
+import { createFeedback } from './db/feedbackQueries.js';
 import { deleteExpiredGuestPlayers } from './db/queries.js';
 import { runMigrations } from './db/client.js';
 import { getPlayerPosition } from './rooms/services/RedisAPStore.js';
@@ -101,6 +103,42 @@ export default config({
         });
       } catch (err) {
         logger.error({ err }, 'Guest login error');
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    });
+
+    app.post('/api/feedback', async (req: Request, res: Response) => {
+      try {
+        const authHeader = req.headers.authorization;
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+          res.status(401).json({ error: 'Authentication required' });
+          return;
+        }
+        let auth: AuthPayload;
+        try {
+          auth = verifyToken(authHeader.slice(7));
+        } catch {
+          res.status(401).json({ error: 'Invalid token' });
+          return;
+        }
+        if (auth.isGuest) {
+          res.status(403).json({ error: 'Guests cannot submit feedback' });
+          return;
+        }
+        const result = validateFeedbackInput(req.body);
+        if ('error' in result) {
+          res.status(400).json({ error: result.error });
+          return;
+        }
+        const id = await createFeedback({
+          playerId: auth.userId,
+          username: auth.username,
+          category: result.category,
+          message: result.message,
+        });
+        res.status(201).json({ id });
+      } catch (err) {
+        logger.error({ err }, 'Feedback submit error');
         res.status(500).json({ error: 'Internal server error' });
       }
     });

--- a/packages/server/src/db/feedbackQueries.ts
+++ b/packages/server/src/db/feedbackQueries.ts
@@ -1,0 +1,57 @@
+import { query } from './client.js';
+
+export interface FeedbackRow {
+  id: number;
+  playerId: string | null;
+  username: string | null;
+  category: string;
+  message: string;
+  status: string;
+  createdAt: string;
+}
+
+export async function createFeedback(input: {
+  playerId: string | null;
+  username: string | null;
+  category: string;
+  message: string;
+}): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO feedback (player_id, username, category, message)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [input.playerId, input.username, input.category, input.message],
+  );
+  return res.rows[0].id;
+}
+
+export async function getFeedback(limit = 100): Promise<FeedbackRow[]> {
+  const res = await query<{
+    id: number;
+    player_id: string | null;
+    username: string | null;
+    category: string;
+    message: string;
+    status: string;
+    created_at: string;
+  }>(
+    `SELECT id, player_id, username, category, message, status, created_at
+       FROM feedback
+      ORDER BY created_at DESC
+      LIMIT $1`,
+    [limit],
+  );
+  return res.rows.map((r) => ({
+    id: r.id,
+    playerId: r.player_id,
+    username: r.username,
+    category: r.category,
+    message: r.message,
+    status: r.status,
+    createdAt: r.created_at,
+  }));
+}
+
+export async function setFeedbackStatus(id: number, status: string): Promise<void> {
+  await query(`UPDATE feedback SET status = $1 WHERE id = $2`, [status, id]);
+}

--- a/packages/server/src/db/migrations/085_feedback.sql
+++ b/packages/server/src/db/migrations/085_feedback.sql
@@ -1,0 +1,12 @@
+-- Feedback: player-submitted feedback shown in the admin console
+CREATE TABLE IF NOT EXISTS feedback (
+  id SERIAL PRIMARY KEY,
+  player_id UUID,
+  username VARCHAR(64),
+  category VARCHAR(16) NOT NULL DEFAULT 'other',  -- bug | idea | praise | other
+  message  TEXT NOT NULL,
+  status   VARCHAR(16) NOT NULL DEFAULT 'new',     -- new | done
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_status_created ON feedback (status, created_at DESC);

--- a/packages/server/src/feedbackValidation.ts
+++ b/packages/server/src/feedbackValidation.ts
@@ -1,0 +1,23 @@
+const CATEGORIES = ['bug', 'idea', 'praise', 'other'] as const;
+export type FeedbackCategory = (typeof CATEGORIES)[number];
+
+export interface ValidFeedback {
+  category: FeedbackCategory;
+  message: string;
+}
+export interface FeedbackError {
+  error: string;
+}
+
+/** Pure validation for incoming feedback. Returns the normalized payload or an error. */
+export function validateFeedbackInput(body: unknown): ValidFeedback | FeedbackError {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const message = typeof b.message === 'string' ? b.message.trim() : '';
+  if (message.length === 0) return { error: 'message required' };
+  if (message.length > 2000) return { error: 'message too long (max 2000)' };
+  const raw = typeof b.category === 'string' ? b.category : 'other';
+  const category = (CATEGORIES as readonly string[]).includes(raw)
+    ? (raw as FeedbackCategory)
+    : 'other';
+  return { category, message };
+}


### PR DESCRIPTION
## Summary
- Floating FEEDBACK button (logged-in, non-guest players) opens a modal: category (Bug/Idee/Lob/Sonstiges) + message → `POST /api/feedback` (player-token auth, guests 403).
- New `feedback` table (migration 085), `feedbackQueries`, pure `validateFeedbackInput`.
- Admin console gets a FEEDBACK tab (list newest-first, mark new/done); user content rendered via `textContent` (XSS-safe).
- `first_feedback` HelpSlice.

## Test Plan
- [x] Server: 1446 pass (+6 feedbackValidation)
- [x] Client: 825 pass (+4 FeedbackButton)
- [x] Adversarial review: APPROVE-WITH-NITS → nits fixed (isNaN guard, limit fallback, comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)