### PR TITLE
fix: createPlayer param type cast ($3::text)

### DIFF
--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -35,7 +35,7 @@ export async function createPlayer(
     email_verified: boolean;
   }>(
     `INSERT INTO players (username, password_hash, email, email_verified, verification_token, verification_sent_at)
-     VALUES ($1, $2, $3, $4, $5, CASE WHEN $3 IS NULL THEN NULL ELSE NOW() END)
+     VALUES ($1, $2, $3::text, $4, $5, CASE WHEN $3::text IS NULL THEN NULL ELSE NOW() END)
      RETURNING id, username, xp, level, email_verified`,
     [username, passwordHash, email, emailVerified, verificationToken],
   );


### PR DESCRIPTION
Hotfix: registration 500'd in prod — Postgres 'could not determine data type of parameter $3' because $3 (email) was only referenced in 'CASE WHEN $3 IS NULL'. Cast to ::text. Caught by the production register E2E (unit tests mock the DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)