### PR TITLE
feat: verify UX (friendly messages + resend) + prettier emails

### DIFF
--- a/packages/client/src/__tests__/EmailVerifyBanner.test.tsx
+++ b/packages/client/src/__tests__/EmailVerifyBanner.test.tsx
@@ -1,13 +1,19 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { EmailVerifyBanner } from '../components/EmailVerifyBanner';
 import { mockStoreState } from '../test/mockStore';
 
 describe('EmailVerifyBanner', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('shows for a logged-in non-guest with unverified email', () => {
     mockStoreState({ token: 'tok', isGuest: false, emailVerified: false } as any);
     render(<EmailVerifyBanner />);
     expect(screen.getByTestId('email-verify-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('resend-verification-btn')).toBeInTheDocument();
   });
 
   it('is hidden when the email is verified', () => {
@@ -26,5 +32,32 @@ describe('EmailVerifyBanner', () => {
     mockStoreState({ token: null, isGuest: false, emailVerified: false } as any);
     render(<EmailVerifyBanner />);
     expect(screen.queryByTestId('email-verify-banner')).toBeNull();
+  });
+
+  it('resend posts to /api/resend-verification with the auth header', async () => {
+    mockStoreState({ token: 'tok123', isGuest: false, emailVerified: false } as any);
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ status: 'sent' }) } as Response);
+    render(<EmailVerifyBanner />);
+    await userEvent.click(screen.getByTestId('resend-verification-btn'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/api/resend-verification');
+    expect(opts.method).toBe('POST');
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer tok123');
+    await waitFor(() => expect(screen.getByText(/Mail gesendet/)).toBeInTheDocument());
+  });
+
+  it('marks verified when the server says already_verified', async () => {
+    const setEmailVerified = vi.fn();
+    mockStoreState({ token: 'tok', isGuest: false, emailVerified: false, setEmailVerified } as any);
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'already_verified' }),
+    } as Response);
+    render(<EmailVerifyBanner />);
+    await userEvent.click(screen.getByTestId('resend-verification-btn'));
+    await waitFor(() => expect(setEmailVerified).toHaveBeenCalledWith(true));
   });
 });

--- a/packages/client/src/components/EmailVerifyBanner.tsx
+++ b/packages/client/src/components/EmailVerifyBanner.tsx
@@ -1,12 +1,44 @@
+import { useState } from 'react';
 import { useStore } from '../state/store';
 
-/** Top banner shown to logged-in (non-guest) users whose email isn't verified yet. */
+/** Top banner for logged-in (non-guest) users whose email isn't verified yet, with a resend button. */
 export function EmailVerifyBanner() {
   const token = useStore((s) => s.token);
   const isGuest = useStore((s) => s.isGuest);
   const emailVerified = useStore((s) => s.emailVerified);
+  const setEmailVerified = useStore((s) => s.setEmailVerified);
+  const addLogEntry = useStore((s) => s.addLogEntry);
+  const [status, setStatus] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
 
   if (!token || isGuest || emailVerified) return null;
+
+  async function resend() {
+    if (sending) return;
+    setSending(true);
+    setStatus(null);
+    try {
+      const API_URL = import.meta.env.VITE_API_URL || '';
+      const res = await fetch(`${API_URL}/api/resend-verification`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json().catch(() => ({}))) as { status?: string; error?: string };
+      if (res.ok && data.status === 'already_verified') {
+        setEmailVerified(true);
+        addLogEntry('E-Mail bereits bestätigt.');
+      } else if (res.ok) {
+        setStatus('Mail gesendet — schau in dein Postfach.');
+        addLogEntry('Bestätigungsmail erneut gesendet.');
+      } else {
+        setStatus(data.error || `Fehler ${res.status}`);
+      }
+    } catch {
+      setStatus('Senden fehlgeschlagen.');
+    } finally {
+      setSending(false);
+    }
+  }
 
   return (
     <div
@@ -22,12 +54,35 @@ export function EmailVerifyBanner() {
         color: 'var(--color-primary)',
         fontFamily: 'var(--font-mono)',
         fontSize: '0.72rem',
-        letterSpacing: '0.05em',
+        letterSpacing: '0.04em',
         textAlign: 'center',
-        padding: '4px 8px',
+        padding: '5px 8px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        flexWrap: 'wrap',
       }}
     >
-      ⚠ Bitte bestätige deine E-Mail-Adresse — der Bestätigungslink wurde dir gesendet.
+      <span>⚠ Bitte bestätige deine E-Mail-Adresse{status ? ` — ${status}` : ''}</span>
+      <button
+        data-testid="resend-verification-btn"
+        onClick={resend}
+        disabled={sending}
+        style={{
+          background: 'none',
+          border: '1px solid var(--color-primary)',
+          color: 'var(--color-primary)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: '0.68rem',
+          letterSpacing: '0.05em',
+          padding: '1px 8px',
+          cursor: sending ? 'default' : 'pointer',
+          opacity: sending ? 0.6 : 1,
+        }}
+      >
+        {sending ? '…' : 'Mail erneut senden'}
+      </button>
     </div>
   );
 }

--- a/packages/server/src/__tests__/emailTemplates.test.ts
+++ b/packages/server/src/__tests__/emailTemplates.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { renderVerificationEmail, escapeHtml } from '../emailTemplates.js';
+
+describe('escapeHtml', () => {
+  it('escapes HTML-significant characters', () => {
+    expect(escapeHtml('<b>"x"&\'y\'')).toBe('&lt;b&gt;&quot;x&quot;&amp;&#39;y&#39;');
+  });
+});
+
+describe('renderVerificationEmail', () => {
+  const link = 'https://voidsector.mr-development.de/api/verify?token=abc123';
+
+  it('includes subject, the verify link (text + html), and the username', () => {
+    const m = renderVerificationEmail('vs1pilot', link);
+    expect(m.subject).toContain('VOID SECTOR');
+    expect(m.text).toContain(link);
+    expect(m.text).toContain('vs1pilot');
+    expect(m.html).toContain(link);
+    expect(m.html).toContain('vs1pilot');
+    expect(m.html).toContain('<!doctype html>');
+  });
+
+  it('escapes a username with HTML in the HTML body (no injection)', () => {
+    const m = renderVerificationEmail('<script>x</script>', link);
+    expect(m.html).not.toContain('<script>x</script>');
+    expect(m.html).toContain('&lt;script&gt;');
+    // plain-text body keeps the raw username (no HTML escaping needed there)
+    expect(m.text).toContain('<script>x</script>');
+  });
+});

--- a/packages/server/src/app.config.ts
+++ b/packages/server/src/app.config.ts
@@ -10,13 +10,17 @@ import { SectorRoom } from './rooms/SectorRoom.js';
 import { register, login, loginAsGuest, verifyToken, type AuthPayload } from './auth.js';
 import { validateFeedbackInput } from './feedbackValidation.js';
 import { validateRegisterInput } from './emailValidation.js';
+import { sendVerificationEmail } from './emailService.js';
 import { createFeedback } from './db/feedbackQueries.js';
 import {
   deleteExpiredGuestPlayers,
-  findPlayerIdByVerificationToken,
+  getVerificationByToken,
   markEmailVerified,
   recentRegistrationForEmail,
+  getPlayerVerificationInfo,
+  setVerificationToken,
 } from './db/queries.js';
+import crypto from 'crypto';
 import { runMigrations } from './db/client.js';
 import { getPlayerPosition } from './rooms/services/RedisAPStore.js';
 import { adminRouter } from './adminRoutes.js';
@@ -95,37 +99,105 @@ export default config({
 
     app.get('/api/verify', async (req: Request, res: Response) => {
       const token = typeof req.query.token === 'string' ? req.query.token : '';
-      const page = (title: string, body: string) =>
+      const appUrl = process.env.APP_PUBLIC_URL || 'http://localhost:3201';
+      const page = (title: string, heading: string, body: string, accent = '#ffb000') =>
         `<!doctype html><html lang="de"><head><meta charset="utf-8">` +
-        `<meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title>` +
-        `<style>body{background:#0a0a0a;color:#ffb000;font-family:monospace;display:flex;` +
-        `align-items:center;justify-content:center;height:100vh;margin:0}` +
-        `.box{border:1px solid #ffb000;padding:24px 32px;max-width:420px;text-align:center}` +
-        `a{color:#ffb000}</style></head><body><div class="box">${body}</div></body></html>`;
+        `<meta name="viewport" content="width=device-width,initial-scale=1"><title>${title} · VOID SECTOR</title>` +
+        `<style>*{box-sizing:border-box}body{background:#05060a;color:#cdd3dc;` +
+        `font-family:'Segoe UI',Arial,Helvetica,sans-serif;display:flex;align-items:center;` +
+        `justify-content:center;min-height:100vh;margin:0;padding:16px}` +
+        `.box{background:#0d1018;border:1px solid #1d2433;border-radius:10px;max-width:420px;width:100%;padding:32px;text-align:center}` +
+        `.brand{font-size:13px;letter-spacing:4px;color:${accent};font-weight:bold;margin-bottom:18px}` +
+        `h2{font-size:18px;margin:0 0 10px;color:#e6eaf0}p{font-size:14px;line-height:1.6;color:#aab2c0;margin:0 0 20px}` +
+        `.btn{display:inline-block;background:${accent};color:#0a0d14;text-decoration:none;font-weight:bold;` +
+        `letter-spacing:1px;padding:11px 26px;border-radius:6px;font-size:13px}</style></head>` +
+        `<body><div class="box"><div class="brand">◈ VOID SECTOR</div><h2>${heading}</h2><p>${body}</p>` +
+        `<a class="btn" href="${appUrl}">ZUM SPIEL &rarr;</a></div></body></html>`;
       try {
         if (!token) {
-          res.status(400).send(page('Ungültig', '<h2>VOID SECTOR</h2><p>Ungültiger Bestätigungslink.</p>'));
+          res
+            .status(400)
+            .send(page('Ungültig', 'Ungültiger Link', 'Dieser Bestätigungslink ist unvollständig.', '#ff6b6b'));
           return;
         }
-        const playerId = await findPlayerIdByVerificationToken(token);
-        if (!playerId) {
+        const info = await getVerificationByToken(token);
+        if (!info) {
           res
             .status(404)
-            .send(page('Abgelaufen', '<h2>VOID SECTOR</h2><p>Link ungültig oder bereits benutzt.</p>'));
+            .send(
+              page(
+                'Abgelaufen',
+                'Link nicht gültig',
+                'Dieser Bestätigungslink ist ungültig oder abgelaufen. Falls deine E-Mail bereits bestätigt ist, logge dich einfach ein.',
+                '#ff6b6b',
+              ),
+            );
           return;
         }
-        await markEmailVerified(playerId);
-        const appUrl = process.env.APP_PUBLIC_URL || 'http://localhost:3201';
+        if (info.emailVerified) {
+          res.send(
+            page(
+              'Bereits bestätigt',
+              'Bereits bestätigt ✓',
+              'Diese E-Mail-Adresse ist bereits bestätigt. Du kannst dich direkt einloggen.',
+            ),
+          );
+          return;
+        }
+        await markEmailVerified(info.id);
         res.send(
-          page(
-            'Bestätigt',
-            '<h2>VOID SECTOR</h2><p>✔ E-Mail bestätigt. Du kannst dich jetzt einloggen.</p>' +
-              `<p><a href="${appUrl}">Zum Spiel →</a></p>`,
-          ),
+          page('Bestätigt', 'E-Mail bestätigt ✓', 'Willkommen an Bord, Pilot! Dein Zugang ist jetzt aktiv.'),
         );
       } catch (err) {
         logger.error({ err }, 'Email verify error');
-        res.status(500).send(page('Fehler', '<h2>VOID SECTOR</h2><p>Interner Fehler.</p>'));
+        res
+          .status(500)
+          .send(page('Fehler', 'Interner Fehler', 'Bitte versuche es später erneut.', '#ff6b6b'));
+      }
+    });
+
+    app.post('/api/resend-verification', async (req: Request, res: Response) => {
+      try {
+        const authHeader = req.headers.authorization;
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+          res.status(401).json({ error: 'Authentication required' });
+          return;
+        }
+        let auth: AuthPayload;
+        try {
+          auth = verifyToken(authHeader.slice(7));
+        } catch {
+          res.status(401).json({ error: 'Invalid token' });
+          return;
+        }
+        if (auth.isGuest) {
+          res.status(403).json({ error: 'Guests have no email' });
+          return;
+        }
+        const info = await getPlayerVerificationInfo(auth.userId);
+        if (!info || !info.email) {
+          res.status(400).json({ error: 'Kein E-Mail-Konto für diesen Account.' });
+          return;
+        }
+        if (info.emailVerified) {
+          res.json({ status: 'already_verified' });
+          return;
+        }
+        if (await recentRegistrationForEmail(info.email, 120)) {
+          res
+            .status(429)
+            .json({ error: 'Bitte warte ein paar Minuten, bevor du es erneut versuchst.' });
+          return;
+        }
+        const token = crypto.randomBytes(32).toString('hex');
+        await setVerificationToken(auth.userId, token);
+        sendVerificationEmail(info.email, auth.username, token).catch((err) =>
+          logger.error({ err }, 'resend verification email failed'),
+        );
+        res.json({ status: 'sent' });
+      } catch (err) {
+        logger.error({ err }, 'Resend verification error');
+        res.status(500).json({ error: 'Internal server error' });
       }
     });
 

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -105,13 +105,16 @@ export async function findPlayerByUsername(
   };
 }
 
-/** Returns the player id owning a verification token, or null. */
-export async function findPlayerIdByVerificationToken(token: string): Promise<string | null> {
-  const result = await query<{ id: string }>(
-    'SELECT id FROM players WHERE verification_token = $1',
+/** Returns the player id + current verified state for a verification token, or null if unknown. */
+export async function getVerificationByToken(
+  token: string,
+): Promise<{ id: string; emailVerified: boolean } | null> {
+  const result = await query<{ id: string; email_verified: boolean }>(
+    'SELECT id, email_verified FROM players WHERE verification_token = $1',
     [token],
   );
-  return result.rows[0]?.id ?? null;
+  const row = result.rows[0];
+  return row ? { id: row.id, emailVerified: row.email_verified } : null;
 }
 
 /**
@@ -132,11 +135,39 @@ export async function recentRegistrationForEmail(
   return result.rows[0]?.exists ?? false;
 }
 
-/** Marks a player's email verified and clears the one-time verification token. */
+/**
+ * Marks a player's email verified. Keeps the token so a re-click of the same link can be
+ * recognized as "already verified" (idempotent — re-clicks never change anything else).
+ */
 export async function markEmailVerified(playerId: string): Promise<void> {
-  await query('UPDATE players SET email_verified = TRUE, verification_token = NULL WHERE id = $1', [
-    playerId,
-  ]);
+  await query('UPDATE players SET email_verified = TRUE WHERE id = $1', [playerId]);
+}
+
+/** Email/verification state for a player (for resend). */
+export async function getPlayerVerificationInfo(
+  playerId: string,
+): Promise<{ email: string | null; emailVerified: boolean; verificationSentAt: string | null } | null> {
+  const result = await query<{
+    email: string | null;
+    email_verified: boolean;
+    verification_sent_at: string | null;
+  }>('SELECT email, email_verified, verification_sent_at FROM players WHERE id = $1', [playerId]);
+  const row = result.rows[0];
+  return row
+    ? {
+        email: row.email,
+        emailVerified: row.email_verified,
+        verificationSentAt: row.verification_sent_at,
+      }
+    : null;
+}
+
+/** Sets a fresh verification token + send timestamp (for resend). */
+export async function setVerificationToken(playerId: string, token: string): Promise<void> {
+  await query(
+    'UPDATE players SET verification_token = $1::text, verification_sent_at = NOW() WHERE id = $2',
+    [token, playerId],
+  );
 }
 
 export async function getMiningStoryIndex(playerId: string): Promise<number> {

--- a/packages/server/src/emailService.ts
+++ b/packages/server/src/emailService.ts
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer';
 import type { Transporter } from 'nodemailer';
 import { logger } from './utils/logger.js';
+import { renderVerificationEmail } from './emailTemplates.js';
 
 const FROM = process.env.EMAIL_FROM || 'noreply@mr-development.de';
 const HOST = process.env.EMAIL_SMTP_HOST || 'mail.mr-development.de';
@@ -29,13 +30,6 @@ export function isEmailEnabled(): boolean {
   return !!PASS;
 }
 
-function escapeHtml(s: string): string {
-  return s.replace(
-    /[&<>"']/g,
-    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string,
-  );
-}
-
 /**
  * Sends the verification email. Best-effort: if SMTP is not configured the call is a no-op
  * (logged), so registration still succeeds in dev/test.
@@ -51,19 +45,7 @@ export async function sendVerificationEmail(
     logger.warn({ to }, 'Email disabled (no EMAIL_SMTP_PASS) — skipping verification mail');
     return;
   }
-  await t.sendMail({
-    from: FROM,
-    to,
-    subject: 'VOID SECTOR — E-Mail bestätigen',
-    text:
-      `Willkommen an Bord, ${username}!\n\n` +
-      `Bitte bestätige deine E-Mail-Adresse über diesen Link:\n${link}\n\n` +
-      `Wenn du dich nicht registriert hast, ignoriere diese Nachricht.`,
-    html:
-      `<p>Willkommen an Bord, <strong>${escapeHtml(username)}</strong>!</p>` +
-      `<p>Bitte bestätige deine E-Mail-Adresse:</p>` +
-      `<p><a href="${link}">${link}</a></p>` +
-      `<p style="color:#888">Wenn du dich nicht registriert hast, ignoriere diese Nachricht.</p>`,
-  });
+  const mail = renderVerificationEmail(username, link);
+  await t.sendMail({ from: FROM, to, subject: mail.subject, text: mail.text, html: mail.html });
   logger.info({ to }, 'Verification email sent');
 }

--- a/packages/server/src/emailTemplates.ts
+++ b/packages/server/src/emailTemplates.ts
@@ -1,0 +1,49 @@
+/** HTML-escape for interpolating user-controlled text into email HTML. */
+export function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string,
+  );
+}
+
+export interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+/** Branded verification email (dark terminal/space theme), email-client-safe (tables + inline styles). */
+export function renderVerificationEmail(username: string, verifyLink: string): RenderedEmail {
+  const u = escapeHtml(username);
+  const subject = 'VOID SECTOR — E-Mail bestätigen';
+  const text =
+    `Willkommen an Bord, ${username}!\n\n` +
+    `Aktiviere deinen Pilotenzugang — bestätige deine E-Mail-Adresse:\n${verifyLink}\n\n` +
+    `Wenn du dich nicht registriert hast, ignoriere diese Nachricht.\n\n— VOID SECTOR`;
+  const html = `<!doctype html>
+<html lang="de"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#05060a;color:#cdd3dc;font-family:Arial,Helvetica,sans-serif">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#05060a;padding:32px 12px">
+    <tr><td align="center">
+      <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background:#0d1018;border:1px solid #1d2433;border-radius:10px;overflow:hidden">
+        <tr><td style="background:#11151f;padding:24px 28px;border-bottom:1px solid #1d2433">
+          <div style="font-size:20px;letter-spacing:4px;color:#ffb000;font-weight:bold">◈ VOID SECTOR</div>
+          <div style="font-size:12px;letter-spacing:2px;color:#5b6478;margin-top:4px">PILOT-REGISTRIERUNG</div>
+        </td></tr>
+        <tr><td style="padding:28px">
+          <p style="margin:0 0 14px;font-size:15px;color:#e6eaf0">Willkommen an Bord, <strong style="color:#ffb000">${u}</strong>!</p>
+          <p style="margin:0 0 22px;font-size:14px;line-height:1.6;color:#aab2c0">Aktiviere deinen Zugang zum Sektor — bestätige deine E-Mail-Adresse mit einem Klick:</p>
+          <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 22px"><tr><td style="border-radius:6px;background:#ffb000">
+            <a href="${verifyLink}" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:bold;letter-spacing:1px;color:#0a0d14;text-decoration:none">E-MAIL BESTÄTIGEN &rarr;</a>
+          </td></tr></table>
+          <p style="margin:0 0 6px;font-size:11px;color:#5b6478">Falls der Button nicht funktioniert, kopiere diesen Link:</p>
+          <p style="margin:0 0 20px;font-size:11px;word-break:break-all"><a href="${verifyLink}" style="color:#5aa9e6">${verifyLink}</a></p>
+          <p style="margin:0;font-size:11px;color:#4a5160;border-top:1px solid #1d2433;padding-top:16px">Wenn du dich nicht registriert hast, ignoriere diese Nachricht einfach.</p>
+        </td></tr>
+        <tr><td style="background:#0a0d14;padding:14px 28px;border-top:1px solid #1d2433;font-size:10px;letter-spacing:1px;color:#3a4150">VOID SECTOR · voidsector.mr-development.de</td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>`;
+  return { subject, text, html };
+}


### PR DESCRIPTION
Friendlier /api/verify (verified / already-verified / invalid), POST /api/resend-verification + banner button, and a branded dark-themed HTML verification email. Server 1455 / client 831 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)