### PR TITLE
fix: verify banner overlaid NAV-COM (render in-flow)

### DIFF
--- a/packages/client/src/__tests__/EmailVerifyBanner.test.tsx
+++ b/packages/client/src/__tests__/EmailVerifyBanner.test.tsx
@@ -16,6 +16,13 @@ describe('EmailVerifyBanner', () => {
     expect(screen.getByTestId('resend-verification-btn')).toBeInTheDocument();
   });
 
+  it('renders in-flow (not a fixed overlay) so it reserves space and cannot cover the cockpit', () => {
+    // Regression: a position:fixed top banner overlaid the NAV-COM program button.
+    mockStoreState({ token: 'tok', isGuest: false, emailVerified: false } as any);
+    render(<EmailVerifyBanner />);
+    expect(screen.getByTestId('email-verify-banner').style.position).not.toBe('fixed');
+  });
+
   it('is hidden when the email is verified', () => {
     mockStoreState({ token: 'tok', isGuest: false, emailVerified: true } as any);
     render(<EmailVerifyBanner />);

--- a/packages/client/src/components/EmailVerifyBanner.tsx
+++ b/packages/client/src/components/EmailVerifyBanner.tsx
@@ -44,11 +44,8 @@ export function EmailVerifyBanner() {
     <div
       data-testid="email-verify-banner"
       style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 9500,
+        flexShrink: 0,
+        width: '100%',
         background: '#3a2a00',
         borderBottom: '1px solid var(--color-primary)',
         color: 'var(--color-primary)',

--- a/packages/client/src/components/GameScreen.tsx
+++ b/packages/client/src/components/GameScreen.tsx
@@ -447,6 +447,9 @@ export function GameScreen() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* In-flow top banner (reserves space; must not overlay the cockpit/NAV button) */}
+      <EmailVerifyBanner />
+
       {/* Desktop layout (>= 1024px) */}
       <CockpitLayout renderScreen={renderCockpitScreen} />
 
@@ -485,7 +488,6 @@ export function GameScreen() {
       <CompendiumOverlay />
       <HelpOverlay />
       <FeedbackButton />
-      <EmailVerifyBanner />
       <AncientRuinDialog />
       <StationTerminalGate />
     </div>


### PR DESCRIPTION
Unverified-email banner was `position:fixed;top:0` → overlaid the cockpit's top, hiding the NAV-COM program button (couldn't return to the map from Mining). Now rendered in-flow as the first GameScreen child so it reserves space. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)