### PR TITLE
feat: UI clarity — bigger/legible fonts + disabled-action hover hints

### DIFF
--- a/docs/superpowers/specs/2026-05-29-ui-clarity-design.md
+++ b/docs/superpowers/specs/2026-05-29-ui-clarity-design.md
@@ -1,0 +1,32 @@
+# UI Clarity — bigger fonts + disabled-action hints
+
+**Date:** 2026-05-29 · **Status:** approved (design)
+
+## Goal
+Make the UI clearer: (1) larger, more legible default text with a user size control; (2) on-hover tooltips explaining why a core action is currently not possible.
+
+## A) Typography
+- **Bigger default:** `:root` font-size 23 → **25px** (`global.css`). All fonts are `rem`-anchored, so this scales the whole UI proportionally (the ~7 `px` outliers are intentional bezel chrome and stay).
+- **Higher contrast:** `--color-dim` alpha 0.6 → **0.75** in `global.css` AND in all 4 profiles in `themes.ts` (color profiles override `--color-dim` at runtime, so both must change).
+- **Size control:** new `fontScale` in `uiSlice` (localStorage `vs-font-scale`, default 1.0), applied in `GameScreen` via `document.documentElement.style.fontSize = ${BASE_FONT_PX * fontScale}px` (BASE_FONT_PX = 25). `SettingsPanel` gets an **S / M / L** segmented control → fontScale 0.92 / 1.0 / 1.16 (≈ 23 / 25 / 29px), default M. New i18n key `settings.fontSize`.
+
+## B) Disabled-action hover hints
+- New reusable **`Hint`** component (`components/Hint.tsx`): `<Hint reason={string|null}>{children}</Hint>`. When `reason` is set, wraps children in a relative hover span and shows a CRT-styled tooltip (dark bg, amber border, mono, small) above on hover. `reason == null` → renders children unchanged. The hover lives on the WRAPPER (disabled buttons don't emit hover events themselves).
+- Applied to ~8 core actions, deriving a reason string from the existing disable conditions, reusing flat i18n `reasons.*` keys (`noAp`, `insufficientCredits`, `cargoFull`, `notAtStation`, `miningActive`, `outOfRange`) + new keys (`insufficientResources`, `insufficientWissen`, `techLocked`, `maxLevel`):
+  - Navigate/Jump + Local/Area Scan (`NavControls`) — mining active / not enough AP
+  - Mine (`MiningScreen`/mobile) — no minable resource / not enough AP / cargo full
+  - Buy/Sell (`NpcTradeView`) — not enough credits / not enough goods
+  - Station + module repair (`RepairPanel`) — not enough credits / resources
+  - ACEP boost (`AcepTab`) — max level / not enough credits / Wissen
+  - Research/buy tech (`TechScreen`) — not enough Wissen / tech locked
+- A `reason` helper per site (small inline function) maps the booleans to a localized string. No global "disabled reason" engine (YAGNI).
+
+## Testing
+- `fontScale` application: GameScreen sets root font-size from the store value (unit/integration).
+- `Hint`: renders children only when `reason` null; shows tooltip with the reason text on mouse-enter, hides on leave (RTL).
+- One targeted test per touched screen asserting the disabled action carries a hint reason (where practical).
+
+## Out of scope (YAGNI)
+- Tooltips on every disabled button app-wide (only the core actions).
+- Animations/transitions on the tooltip; tooltip auto-positioning/flipping (fixed above-center placement).
+- Applying `brightness` to the DOM (pre-existing unused setting — untouched).

--- a/packages/client/src/__tests__/Hint.test.tsx
+++ b/packages/client/src/__tests__/Hint.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Hint } from '../components/Hint';
+
+describe('Hint', () => {
+  it('renders children unchanged when reason is null', () => {
+    render(
+      <Hint reason={null}>
+        <button>GO</button>
+      </Hint>,
+    );
+    expect(screen.getByText('GO')).toBeInTheDocument();
+    expect(screen.queryByTestId('hint-wrap')).toBeNull();
+  });
+
+  it('shows the reason tooltip on hover and hides on leave', () => {
+    render(
+      <Hint reason="KEIN AP">
+        <button disabled>JUMP</button>
+      </Hint>,
+    );
+    const wrap = screen.getByTestId('hint-wrap');
+    expect(screen.queryByTestId('hint-tooltip')).toBeNull();
+    fireEvent.mouseEnter(wrap);
+    expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('KEIN AP');
+    fireEvent.mouseLeave(wrap);
+    expect(screen.queryByTestId('hint-tooltip')).toBeNull();
+  });
+});

--- a/packages/client/src/components/AcepTab.tsx
+++ b/packages/client/src/components/AcepTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
+import { Hint } from './Hint';
 import type { AcepPath } from '@void-sector/shared';
 import { getAcepBoostCost } from '@void-sector/shared';
 
@@ -157,14 +158,24 @@ export function AcepTab() {
                 <div style={{ width: `${(level / 10) * 100}%`, height: '100%', background: color }} />
               </div>
               {cost ? (
-                <button
-                  style={{ ...btnStyle, border: `1px solid ${color}`, color, opacity: canBoost ? 1 : 0.35, fontSize: '0.7rem' }}
-                  disabled={!canBoost}
-                  title={`+1 Level: ${cost.credits} CR · ${cost.wissen} W`}
-                  onClick={() => network.sendAcepBoost(key)}
+                <Hint
+                  reason={
+                    canBoost
+                      ? null
+                      : credits < cost.credits
+                        ? t('reasons.insufficientCredits')
+                        : t('reasons.insufficientWissen')
+                  }
                 >
-                  [+1]
-                </button>
+                  <button
+                    style={{ ...btnStyle, border: `1px solid ${color}`, color, opacity: canBoost ? 1 : 0.35, fontSize: '0.7rem' }}
+                    disabled={!canBoost}
+                    title={`+1 Level: ${cost.credits} CR · ${cost.wissen} W`}
+                    onClick={() => network.sendAcepBoost(key)}
+                  >
+                    [+1]
+                  </button>
+                </Hint>
               ) : (
                 <span style={{ color: '#00FF88', fontSize: '0.75rem' }}>MAX</span>
               )}

--- a/packages/client/src/components/GameScreen.tsx
+++ b/packages/client/src/components/GameScreen.tsx
@@ -419,8 +419,12 @@ function renderCockpitScreen(monitorId: string) {
   }
 }
 
+/** Base root font-size (px); the font-size setting scales this. */
+const BASE_FONT_PX = 25;
+
 export function GameScreen() {
   const colorProfile = useStore((s) => s.colorProfile);
+  const fontScale = useStore((s) => s.fontScale);
   const activeMonitor = useStore((s) => s.activeMonitor);
   const setActiveMonitor = useStore((s) => s.setActiveMonitor);
   const clearAlert = useStore((s) => s.clearAlert);
@@ -435,6 +439,11 @@ export function GameScreen() {
     document.documentElement.style.setProperty('--color-primary', profile.primary);
     document.documentElement.style.setProperty('--color-dim', profile.dim);
   }, [colorProfile]);
+
+  // Apply the text-size setting (everything is rem-anchored, so this scales the whole UI).
+  useEffect(() => {
+    document.documentElement.style.fontSize = `${BASE_FONT_PX * fontScale}px`;
+  }, [fontScale]);
 
   useEffect(() => {
     // Only run on mobile viewports to avoid affecting desktop activeProgram logic

--- a/packages/client/src/components/Hint.tsx
+++ b/packages/client/src/components/Hint.tsx
@@ -1,0 +1,61 @@
+import { useState, type ReactNode, type CSSProperties } from 'react';
+
+/**
+ * Wraps an element (typically a disabled action button) and shows a CRT-styled tooltip on hover
+ * explaining why the action is unavailable. When `reason` is null/empty the children render
+ * unchanged (no wrapper). The hover lives on the wrapper span because disabled buttons don't
+ * emit pointer events themselves. Pass `style` (e.g. `{ display: 'flex', width: '100%' }`) to keep
+ * full-width buttons full-width.
+ */
+export function Hint({
+  reason,
+  children,
+  style,
+}: {
+  reason?: string | null;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  const [show, setShow] = useState(false);
+
+  if (!reason) return <>{children}</>;
+
+  return (
+    <span
+      data-testid="hint-wrap"
+      style={{ position: 'relative', display: 'inline-flex', ...style }}
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      {children}
+      {show && (
+        <span
+          role="tooltip"
+          data-testid="hint-tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#0a0a0a',
+            border: '1px solid var(--color-primary)',
+            color: 'var(--color-primary)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.62rem',
+            letterSpacing: '0.04em',
+            lineHeight: 1.3,
+            padding: '4px 8px',
+            maxWidth: 220,
+            width: 'max-content',
+            textAlign: 'center',
+            zIndex: 10000,
+            pointerEvents: 'none',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.6)',
+          }}
+        >
+          {reason}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/client/src/components/NpcTradeView.tsx
+++ b/packages/client/src/components/NpcTradeView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useStore } from '../state/store';
 import { network } from '../network/client';
+import { Hint } from './Hint';
 
 const RESOURCES = ['ore', 'gas', 'crystal'] as const;
 const RES_COLORS: Record<string, string> = { ore: '#FFB000', gas: '#00BFFF', crystal: '#FF44FF' };
@@ -22,12 +24,18 @@ function ResourceTradeRow({
   playerCredits: number;
   playerStock: number;
 }) {
+  const { t } = useTranslation('ui');
   const [qty, setQty] = useState(1);
   const color = RES_COLORS[resource] ?? '#FFB000';
   const isBuy = action === 'buy';
   const maxQty = isBuy ? Math.min(stock, Math.floor(playerCredits / Math.max(1, price))) : playerStock;
   const totalCost = qty * price;
   const canTrade = price > 0 && qty > 0 && qty <= maxQty;
+  const tradeReason = canTrade
+    ? null
+    : isBuy
+      ? t('reasons.insufficientCredits')
+      : t('reasons.insufficientResources');
   const unavailable = isBuy ? stock <= 0 : false;
 
   useEffect(() => {
@@ -68,23 +76,25 @@ function ResourceTradeRow({
         </button>
       </div>
       <span style={{ color: '#555', fontSize: '0.6rem', width: 50 }}>= {totalCost} CR</span>
-      <button
-        className="vs-btn"
-        style={{
-          fontSize: '0.6rem',
-          padding: '2px 8px',
-          borderColor: isBuy ? '#00FF66' : '#FF6644',
-          color: isBuy ? '#00FF66' : '#FF6644',
-        }}
-        disabled={!canTrade}
-        onClick={() => {
-          network.sendNpcShipTrade(npcId, resource, qty, action);
-          // Refresh trade info after short delay
-          setTimeout(() => network.sendGetNpcTradeInfo(npcId), 300);
-        }}
-      >
-        {isBuy ? '[BUY]' : '[SELL]'}
-      </button>
+      <Hint reason={tradeReason}>
+        <button
+          className="vs-btn"
+          style={{
+            fontSize: '0.6rem',
+            padding: '2px 8px',
+            borderColor: isBuy ? '#00FF66' : '#FF6644',
+            color: isBuy ? '#00FF66' : '#FF6644',
+          }}
+          disabled={!canTrade}
+          onClick={() => {
+            network.sendNpcShipTrade(npcId, resource, qty, action);
+            // Refresh trade info after short delay
+            setTimeout(() => network.sendGetNpcTradeInfo(npcId), 300);
+          }}
+        >
+          {isBuy ? '[BUY]' : '[SELL]'}
+        </button>
+      </Hint>
     </div>
   );
 }

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -26,6 +26,8 @@ export const SettingsPanel: React.FC = () => {
   const setColorProfile = useStore((s) => s.setColorProfile);
   const brightness = useStore((s) => s.brightness);
   const setBrightness = useStore((s) => s.setBrightness);
+  const fontScale = useStore((s) => s.fontScale);
+  const setFontScale = useStore((s) => s.setFontScale);
   const openCompendium = useStore((s) => s.openCompendium);
 
   const handleLogout = () => {
@@ -75,6 +77,34 @@ export const SettingsPanel: React.FC = () => {
           data-testid="brightness-slider"
         />
         <span>{brightness.toFixed(1)}</span>
+      </div>
+
+      <div className="settings-row">
+        <span className="settings-label">{t('settings.fontSize')}</span>
+        <div style={{ display: 'flex', gap: 6 }} data-testid="font-size-control">
+          {([
+            ['S', 0.92],
+            ['M', 1.0],
+            ['L', 1.16],
+          ] as const).map(([lbl, val]) => (
+            <button
+              key={lbl}
+              onClick={() => setFontScale(val)}
+              data-testid={`font-size-${lbl}`}
+              style={{
+                background: Math.abs(fontScale - val) < 0.01 ? 'rgba(255,176,0,0.15)' : 'transparent',
+                color: Math.abs(fontScale - val) < 0.01 ? 'var(--color-primary)' : '#666',
+                border: '1px solid #333',
+                padding: '2px 10px',
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.8rem',
+                cursor: 'pointer',
+              }}
+            >
+              {lbl}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div style={{ marginTop: 12 }}>

--- a/packages/client/src/locales/de/ui.json
+++ b/packages/client/src/locales/de/ui.json
@@ -444,5 +444,10 @@
   "detail.refuelLabel": "REFUEL — {{price}}",
   "detail.crPerUnit": "CR/u",
   "detail.refuel": "[AUFTANKEN]",
-  "detail.ancientXenostation": "ANCIENT XENOSTATION"
+  "detail.ancientXenostation": "ANCIENT XENOSTATION",
+  "settings.fontSize": "Schriftgröße",
+  "reasons.insufficientResources": "KEINE RESSOURCEN",
+  "reasons.insufficientWissen": "KEIN WISSEN",
+  "reasons.techLocked": "TECH GESPERRT",
+  "reasons.maxLevel": "MAX LEVEL"
 }

--- a/packages/client/src/locales/en/ui.json
+++ b/packages/client/src/locales/en/ui.json
@@ -444,5 +444,10 @@
   "detail.refuelLabel": "REFUEL — {{price}}",
   "detail.crPerUnit": "CR/u",
   "detail.refuel": "[REFUEL]",
-  "detail.ancientXenostation": "ANCIENT XENOSTATION"
+  "detail.ancientXenostation": "ANCIENT XENOSTATION",
+  "settings.fontSize": "Text size",
+  "reasons.insufficientResources": "NO RESOURCES",
+  "reasons.insufficientWissen": "NO KNOWLEDGE",
+  "reasons.techLocked": "TECH LOCKED",
+  "reasons.maxLevel": "MAX LEVEL"
 }

--- a/packages/client/src/state/uiSlice.ts
+++ b/packages/client/src/state/uiSlice.ts
@@ -36,6 +36,7 @@ export interface UISlice {
   theme: ThemeColor;
   jumpPending: boolean;
   brightness: number;
+  fontScale: number;
   colorProfile: ColorProfileName;
   zoomLevel: number;
   panOffset: { x: number; y: number };
@@ -66,6 +67,7 @@ export interface UISlice {
   setTheme: (theme: ThemeColor) => void;
   setJumpPending: (pending: boolean) => void;
   setBrightness: (val: number) => void;
+  setFontScale: (val: number) => void;
   setColorProfile: (profile: ColorProfileName) => void;
   setZoomLevel: (level: number) => void;
   setPanOffset: (offset: { x: number; y: number }) => void;
@@ -105,6 +107,7 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set, get) 
   theme: (safeGetItem('vs_theme') as ThemeColor) || 'amber',
   jumpPending: false,
   brightness: parseFloat(safeGetItem('vs-brightness') || '1'),
+  fontScale: parseFloat(safeGetItem('vs-font-scale') || '1'),
   colorProfile: (safeGetItem('vs-color-profile') as ColorProfileName) || 'Amber Classic',
   zoomLevel: 2,
   panOffset: { x: 0, y: 0 },
@@ -134,6 +137,10 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set, get) 
   setBrightness: (val) => {
     safeSetItem('vs-brightness', String(val));
     set({ brightness: val });
+  },
+  setFontScale: (val) => {
+    safeSetItem('vs-font-scale', String(val));
+    set({ fontScale: val });
   },
   setColorProfile: (profile) => {
     safeSetItem('vs-color-profile', profile);

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -7,7 +7,8 @@
 }
 
 :root {
-  font-size: 23px;
+  /* Base size; the game screen overrides this from the font-size setting (BASE 25 * fontScale). */
+  font-size: 25px;
   /* Font size tiers */
   --fs-xs:   0.43rem;  /* ~10px — bezel chrome */
   --fs-sm:   0.52rem;  /* ~12px — chrome labels */
@@ -15,7 +16,7 @@
   --fs-base: 0.81rem;  /* ~19px — default content */
   --fs-lg:   0.90rem;  /* ~21px — headers, primary buttons */
   --color-primary: #FFB000;
-  --color-dim: rgba(255, 176, 0, 0.6);
+  --color-dim: rgba(255, 176, 0, 0.75);
   --color-bg: #050505;
   --color-danger: #FF3333;
   --color-bezel: #1a1a1a;

--- a/packages/client/src/styles/themes.ts
+++ b/packages/client/src/styles/themes.ts
@@ -1,8 +1,8 @@
 export const COLOR_PROFILES = {
-  'Amber Classic': { primary: '#FFB000', dim: 'rgba(255, 176, 0, 0.6)' },
-  'Green Phosphor': { primary: '#00FF66', dim: 'rgba(0, 255, 102, 0.6)' },
-  'Ice Blue': { primary: '#00CCFF', dim: 'rgba(0, 204, 255, 0.6)' },
-  'High Contrast': { primary: '#FFFFFF', dim: 'rgba(255, 255, 255, 0.6)' },
+  'Amber Classic': { primary: '#FFB000', dim: 'rgba(255, 176, 0, 0.75)' },
+  'Green Phosphor': { primary: '#00FF66', dim: 'rgba(0, 255, 102, 0.75)' },
+  'Ice Blue': { primary: '#00CCFF', dim: 'rgba(0, 204, 255, 0.75)' },
+  'High Contrast': { primary: '#FFFFFF', dim: 'rgba(255, 255, 255, 0.75)' },
 } as const;
 
 export type ColorProfileName = keyof typeof COLOR_PROFILES;

--- a/packages/client/src/test/mockStore.ts
+++ b/packages/client/src/test/mockStore.ts
@@ -243,6 +243,8 @@ export function mockStoreState(overrides: Partial<StoreState> = {}) {
     setPanOffset: vi.fn(),
     brightness: 1.0,
     setBrightness: vi.fn(),
+    fontScale: 1.0,
+    setFontScale: vi.fn(),
     colorProfile: 'Amber Classic',
     setColorProfile: vi.fn(),
     scanPending: false,


### PR DESCRIPTION
## Summary
**Fonts:** base root size 23→25px (everything is rem-anchored so the whole UI scales proportionally), `--color-dim` 0.6→0.75 for contrast (global + all color profiles). New `fontScale` setting (localStorage) applied in GameScreen; SettingsPanel gains an **S/M/L** control (≈23/25/29px, default M).

**Hover hints:** reusable CRT-styled `<Hint reason>` tooltip (hover on a wrapper span, since disabled buttons emit no pointer events). Applied to the bare-`disabled` actions that didn't already explain themselves — trade BUY/SELL and ACEP boost. Actions that already swap in their reason inline (scan/mine/repair) or render explanatory text (tech) were left as-is.

## Test Plan
- [x] Client suite: 834 pass (+ Hint unit tests)
- [x] Vite build green
- [ ] Visual check on prod (font size + S/M/L + hover a disabled BUY/ACEP button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)