### PR TITLE
fix: TRADE selling at stations + accepting fetch quests with full cargo

### DIFF
--- a/packages/client/src/__tests__/TradeScreen.test.tsx
+++ b/packages/client/src/__tests__/TradeScreen.test.tsx
@@ -26,6 +26,64 @@ describe('TradeScreen', () => {
     mockStoreState({ baseStructures: [] });
   });
 
+  it('requests NPC station data when rendered at a station', () => {
+    mockStoreState({
+      baseStructures: [],
+      position: { x: 10, y: 10 },
+      currentSector: {
+        x: 10,
+        y: 10,
+        type: 'station',
+        seed: 42,
+        discoveredBy: null,
+        discoveredAt: null,
+        metadata: {},
+        environment: 'empty' as const,
+        contents: ['station' as const],
+      },
+      credits: 200,
+      cargo: {
+        ore: 0,
+        gas: 0,
+        crystal: 0,
+        slates: 0,
+        artefact: 0,
+        artefact_drive: 0,
+        artefact_cargo: 0,
+        artefact_scanner: 0,
+        artefact_armor: 0,
+        artefact_weapon: 0,
+        artefact_shield: 0,
+        artefact_defense: 0,
+        artefact_special: 0,
+        artefact_mining: 0,
+      },
+      npcStationData: null,
+    });
+    render(<TradeScreen />);
+    expect(network.requestNpcStationData).toHaveBeenCalled();
+  });
+
+  it('does not request NPC station data when not at a station and no base', () => {
+    mockStoreState({
+      baseStructures: [],
+      position: { x: 5, y: 5 },
+      currentSector: {
+        x: 5,
+        y: 5,
+        type: 'empty',
+        seed: 42,
+        discoveredBy: null,
+        discoveredAt: null,
+        metadata: {},
+        environment: 'empty' as const,
+        contents: [],
+      },
+    });
+    render(<TradeScreen />);
+    expect(network.requestNpcStationData).not.toHaveBeenCalled();
+  });
+
   it('shows no trade available when not at station or home base', () => {
     mockStoreState({
       baseStructures: [],

--- a/packages/client/src/components/TradeScreen.tsx
+++ b/packages/client/src/components/TradeScreen.tsx
@@ -83,6 +83,10 @@ export function TradeScreen() {
     }
   }, [tier]);
 
+  useEffect(() => {
+    if (isStation) network.requestNpcStationData();
+  }, [isStation]);
+
   if (!canTrade) {
     const nearest = findNearestStation(position, discoveries);
     return (

--- a/packages/server/src/__tests__/questService-bountyAccept.test.ts
+++ b/packages/server/src/__tests__/questService-bountyAccept.test.ts
@@ -58,6 +58,8 @@ vi.mock('../rooms/services/RedisAPStore.js', () => ({
 
 import { QuestService } from '../rooms/services/QuestService.js';
 import { insertQuest } from '../db/queries.js';
+import { generateStationQuests } from '../engine/questgen.js';
+import { getCargoState } from '../engine/inventoryService.js';
 
 function makeCtx(overrides = {}) {
   return {
@@ -168,5 +170,62 @@ describe('QuestService.handleAcceptQuest — bounty_chase', () => {
     expect(deliverObj.stationX).toBe(10);
     expect(deliverObj.stationY).toBe(10);
     expect(deliverObj.fulfilled).toBe(false);
+  });
+});
+
+describe('QuestService.handleAcceptQuest — fetch quest with full cargo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts a fetch quest even when cargo is full (delivery verifies items, not accept)', async () => {
+    // A fetch quest: "beschaffe 2 Crystal".
+    vi.mocked(generateStationQuests).mockReturnValue([
+      {
+        templateId: 'fetch_crystal',
+        npcName: 'Quartermaster',
+        npcFactionId: 'humanity',
+        title: 'Beschaffe 2 Crystal',
+        description: 'Liefere 2 Crystal an die Station.',
+        objectives: [
+          {
+            type: 'fetch',
+            description: 'Beschaffe 2 Crystal',
+            fulfilled: false,
+            resource: 'crystal',
+            amount: 2,
+          },
+        ],
+        rewards: { credits: 80, xp: 20, reputation: 5, wissen: 1 },
+        requiredTier: 'neutral',
+      },
+    ] as any);
+
+    // Cargo completely full — the old accept-time check would have rejected here.
+    vi.mocked(getCargoState).mockResolvedValue({
+      ore: 50,
+      gas: 50,
+      crystal: 50,
+      slates: 0,
+      artefact: 0,
+    } as any);
+
+    const ctx = makeCtx() as any;
+    const service = new QuestService(ctx);
+    const client = makeClient() as any;
+
+    await service.handleAcceptQuest(client, {
+      templateId: 'fetch_crystal',
+      stationX: 10,
+      stationY: 10,
+    });
+
+    const sendCalls = (ctx.send as any).mock.calls;
+    const acceptResult = sendCalls.find((c: any[]) => c[1] === 'acceptQuestResult');
+    expect(acceptResult).toBeDefined();
+    // Must NOT be rejected for cargo space.
+    expect(acceptResult[2].error).not.toBe('Zu wenig Laderaum für diese Quest');
+    expect(acceptResult[2].success).toBe(true);
+    expect(insertQuest).toHaveBeenCalled();
   });
 });

--- a/packages/server/src/rooms/services/QuestService.ts
+++ b/packages/server/src/rooms/services/QuestService.ts
@@ -41,7 +41,6 @@ import {
   getAcceptedQuestTemplateIds,
   addWissen,
   getQuestById,
-  getCargoCapForPlayer,
   getInventory,
 } from '../../db/queries.js';
 import {
@@ -131,24 +130,6 @@ export class QuestService {
     let objectives = questTemplate.objectives;
     let title = questTemplate.title;
     let description = questTemplate.description;
-
-    // Fetch quest: check cargo capacity before accepting
-    const fetchObj = objectives.find((o) => o.type === 'fetch');
-    if (fetchObj?.amount) {
-      const [cargoState, cargoCap] = await Promise.all([
-        getCargoState(auth.userId),
-        getCargoCapForPlayer(auth.userId),
-      ]);
-      const currentUsed =
-        cargoState.ore + cargoState.gas + cargoState.crystal + cargoState.slates + cargoState.artefact;
-      if (currentUsed + fetchObj.amount > cargoCap) {
-        this.ctx.send(client, 'acceptQuestResult', {
-          success: false,
-          error: 'Zu wenig Laderaum für diese Quest',
-        });
-        return;
-      }
-    }
 
     // Bounty chase: generate trail at accept time
     if (objectives[0]?.type === 'bounty_trail') {


### PR DESCRIPTION
Two prod bugfixes found during live testing (both predate the programmable-ship feature).

## Bug 1 — can't sell at the TRADE program while at an NPC station (e.g. 0:0)
`TradeScreen` renders the station sell UI only when `isStation && npcStationData`, but `npcStationData` was never requested (the `getNpcStation` request was removed and the server only pushes it after a trade) → chicken-and-egg, no sell UI at a never-traded station. **Fix:** request station data via `network.requestNpcStationData()` in a `useEffect` when entering a station.

## Bug 2 — accepting a "fetch" quest (e.g. "beschaffe 2 Crystal") rejected when cargo is full
`QuestService` rejected acceptance with "Zu wenig Laderaum…" although no item is granted at accept time and delivery already verifies the resources. **Fix:** remove the spurious accept-time cargo check (delivery-time check is sufficient) + drop the now-unused import.

## Tests
- client 894 pass (TradeScreen: requests station data at a station, not otherwise)
- server 1588 pass + build clean (accepting a fetch quest with full cargo now succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)