### PR TITLE
feat: interactive quest turn-in offer at the quest-giver (Aufklärungsmission)

### DIFF
--- a/packages/client/src/__tests__/QuestTurnInOffer.test.tsx
+++ b/packages/client/src/__tests__/QuestTurnInOffer.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QuestTurnInOffer } from '../components/overlays/QuestTurnInOffer';
+import { useStore } from '../state/store';
+
+// Mock network
+const mockSendTurnInQuest = vi.fn();
+vi.mock('../network/client', () => ({
+  network: {
+    sendTurnInQuest: (...args: any[]) => mockSendTurnInQuest(...args),
+  },
+}));
+
+describe('QuestTurnInOffer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStore.setState({ questTurnInOffer: null });
+  });
+
+  it('renders the title and both buttons when an offer is present', () => {
+    useStore.setState({ questTurnInOffer: { questId: 'q1', title: 'Erforsche 7:1' } });
+    render(<QuestTurnInOffer />);
+    expect(screen.getByText(/Erforsche 7:1/)).toBeTruthy();
+    expect(screen.getByText(/QUEST ABSCHLIESSEN/i)).toBeTruthy();
+    expect(screen.getByText(/SPÄTER/i)).toBeTruthy();
+  });
+
+  it('renders nothing when there is no offer', () => {
+    useStore.setState({ questTurnInOffer: null });
+    const { container } = render(<QuestTurnInOffer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('confirms turn-in: calls sendTurnInQuest and clears the offer', () => {
+    useStore.setState({ questTurnInOffer: { questId: 'q1', title: 'Erforsche 7:1' } });
+    render(<QuestTurnInOffer />);
+    fireEvent.click(screen.getByText(/QUEST ABSCHLIESSEN/i));
+    expect(mockSendTurnInQuest).toHaveBeenCalledWith('q1');
+    expect(useStore.getState().questTurnInOffer).toBeNull();
+  });
+
+  it('dismisses with SPÄTER: clears the offer without calling sendTurnInQuest', () => {
+    useStore.setState({ questTurnInOffer: { questId: 'q1', title: 'Erforsche 7:1' } });
+    render(<QuestTurnInOffer />);
+    fireEvent.click(screen.getByText(/SPÄTER/i));
+    expect(mockSendTurnInQuest).not.toHaveBeenCalled();
+    expect(useStore.getState().questTurnInOffer).toBeNull();
+  });
+});

--- a/packages/client/src/components/CockpitLayout.tsx
+++ b/packages/client/src/components/CockpitLayout.tsx
@@ -30,6 +30,7 @@ import { StoryEventOverlay } from './overlays/StoryEventOverlay';
 import { FirstContactNewsOverlay } from './overlays/FirstContactNewsOverlay';
 import { AlienEncounterToast } from './overlays/AlienEncounterToast';
 import { QuestCompleteOverlay } from './overlays/QuestCompleteOverlay';
+import { QuestTurnInOffer } from './overlays/QuestTurnInOffer';
 import { LocalScanResultOverlay } from './overlays/LocalScanResultOverlay';
 import { PlayerCardModal } from './PlayerCardModal';
 import { TradeWindow } from './TradeWindow';
@@ -246,6 +247,7 @@ export function CockpitLayout({ renderScreen }: CockpitLayoutProps) {
       <FirstContactNewsOverlay />
       <AlienEncounterToast />
       <QuestCompleteOverlay />
+      <QuestTurnInOffer />
       <SuccessToast />
     </div>
   );

--- a/packages/client/src/components/overlays/QuestTurnInOffer.tsx
+++ b/packages/client/src/components/overlays/QuestTurnInOffer.tsx
@@ -1,0 +1,63 @@
+import { useStore } from '../../state/store';
+import { network } from '../../network/client';
+
+export function QuestTurnInOffer() {
+  const offer = useStore((s) => s.questTurnInOffer);
+  const setQuestTurnInOffer = useStore((s) => s.setQuestTurnInOffer);
+
+  if (!offer) return null;
+
+  const handleConfirm = () => {
+    network.sendTurnInQuest(offer.questId);
+    setQuestTurnInOffer(null);
+  };
+
+  const handleLater = () => {
+    setQuestTurnInOffer(null);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: 320,
+        border: '1px solid #00FF88',
+        background: '#050505',
+        padding: '16px 18px',
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.75rem',
+        zIndex: 200,
+        boxShadow: '0 0 24px rgba(0,255,136,0.25)',
+      }}
+    >
+      <div
+        style={{
+          color: '#00FF88',
+          fontSize: '0.6rem',
+          letterSpacing: '0.2em',
+          marginBottom: 8,
+        }}
+      >
+        QUEST-ABGABE
+      </div>
+      <div style={{ color: 'var(--color-primary)', marginBottom: 6 }}>{offer.title}</div>
+      <div style={{ color: 'rgba(255,255,255,0.7)', marginBottom: 6 }}>Quest abschließen?</div>
+      {offer.rewardCredits != null && (
+        <div style={{ color: 'rgba(255,176,0,0.7)', fontSize: '0.7rem', marginBottom: 10 }}>
+          Belohnung: {offer.rewardCredits} Credits
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+        <button className="vs-btn" onClick={handleConfirm} style={{ flex: 1 }}>
+          [QUEST ABSCHLIESSEN]
+        </button>
+        <button className="vs-btn" onClick={handleLater} style={{ flex: 1 }}>
+          [SPÄTER]
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/network/client.ts
+++ b/packages/client/src/network/client.ts
@@ -1223,6 +1223,13 @@ class GameNetwork {
       useStore.getState().showTip('first_quest_complete');
     });
 
+    room.onMessage(
+      'questTurnInOffer',
+      (data: { questId: string; title: string; rewardCredits?: number }) => {
+        useStore.getState().setQuestTurnInOffer(data);
+      },
+    );
+
     room.onMessage('trackedQuestsUpdate', (data: { quests: TrackedQuest[] }) => {
       useStore.getState().setTrackedQuests(data.quests);
     });
@@ -2596,6 +2603,10 @@ class GameNetwork {
       return;
     }
     this.sectorRoom.send('deliverQuest', { questId });
+  }
+
+  sendTurnInQuest(questId: string) {
+    this.sectorRoom?.send('turnInQuest', { questId });
   }
 
   sendDeliverQuestResources(questId: string, sectorX: number, sectorY: number) {

--- a/packages/client/src/state/gameSlice.ts
+++ b/packages/client/src/state/gameSlice.ts
@@ -578,6 +578,9 @@ export interface GameSlice {
   // Quest completion
   questCompleteQueue: QuestCompleteEntry[];
 
+  // Interactive quest turn-in offer (server re-offers on next arrival if dismissed)
+  questTurnInOffer: { questId: string; title: string; rewardCredits?: number } | null;
+
   // AQ Story / Community
   storyEvent: StoryEventPayload | null;
   alienEncounterEvent: AlienEncounterEventPayload | null;
@@ -740,6 +743,9 @@ export interface GameSlice {
   setVisitedQuadrants: (quadrants: Array<{ qx: number; qy: number }>) => void;
   addQuestComplete: (entry: QuestCompleteEntry) => void;
   shiftQuestComplete: () => void;
+  setQuestTurnInOffer: (
+    offer: { questId: string; title: string; rewardCredits?: number } | null,
+  ) => void;
   setStoryEvent: (e: StoryEventPayload | null) => void;
   setAlienEncounterEvent: (e: AlienEncounterEventPayload | null) => void;
   setStoryProgress: (p: StoryProgressPayload | null) => void;
@@ -910,6 +916,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
   autoRefuelConfig: { enabled: false, maxPricePerUnit: 10 },
   visitedQuadrants: new Set<string>(),
   questCompleteQueue: [],
+  questTurnInOffer: null,
   storyEvent: null,
   alienEncounterEvent: null,
   storyProgress: null,
@@ -1188,6 +1195,7 @@ export const createGameSlice: StateCreator<GameSlice, [], [], GameSlice> = (set,
     set((s) => ({ questCompleteQueue: [...s.questCompleteQueue, entry] })),
   shiftQuestComplete: () =>
     set((s) => ({ questCompleteQueue: s.questCompleteQueue.slice(1) })),
+  setQuestTurnInOffer: (offer) => set({ questTurnInOffer: offer }),
   setStoryEvent: (e) => set({ storyEvent: e }),
   setAlienEncounterEvent: (e) => set({ alienEncounterEvent: e }),
   setStoryProgress: (p) => set({ storyProgress: p }),

--- a/packages/server/src/__tests__/questService-turnInOffer.test.ts
+++ b/packages/server/src/__tests__/questService-turnInOffer.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db/queries.js', () => ({
+  getActiveQuests: vi.fn(),
+  updateQuestObjectives: vi.fn(),
+  updateQuestStatus: vi.fn(),
+  addCredits: vi.fn(),
+  getPlayerCredits: vi.fn().mockResolvedValue(1000),
+  addPlayerXp: vi.fn().mockResolvedValue({ xp: 40, level: 1 }),
+  setPlayerLevel: vi.fn(),
+  addWissen: vi.fn(),
+  getWissen: vi.fn().mockResolvedValue(0),
+  getQuestById: vi.fn(),
+  setPlayerReputation: vi.fn().mockResolvedValue(12),
+  getPlayerReputations: vi.fn().mockResolvedValue([]),
+  getPlayerUpgrades: vi.fn().mockResolvedValue([]),
+  upsertPlayerUpgrade: vi.fn(),
+  getTrackedQuests: vi.fn().mockResolvedValue([]),
+  getInventory: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../engine/inventoryService.js', () => ({
+  getCargoState: vi.fn().mockResolvedValue({ ore: 0, gas: 0, crystal: 0, artefact: 0 }),
+  addToInventory: vi.fn(),
+  removeFromInventory: vi.fn(),
+  getInventoryItem: vi.fn().mockResolvedValue(0),
+}));
+
+import { QuestService } from '../rooms/services/QuestService.js';
+import {
+  getActiveQuests,
+  updateQuestObjectives,
+  updateQuestStatus,
+  getQuestById,
+  addCredits,
+} from '../db/queries.js';
+import {
+  removeFromInventory,
+  getInventoryItem,
+} from '../engine/inventoryService.js';
+
+// A recon/scan quest: scan a sector, then deliver the data slate back to the
+// giver station at 10:10. Once the scan is done, arriving at 10:10 should OFFER
+// turn-in (not auto-complete).
+function reconQuestRow(scanFulfilled: boolean) {
+  return {
+    id: 'quest-1',
+    template_id: 'scientists_recon',
+    title: 'Aufklärung Sektor 30:30',
+    station_x: 10,
+    station_y: 10,
+    status: 'active',
+    rewards: { credits: 150, xp: 30, reputation: 8, wissen: 4 },
+    objectives: [
+      {
+        type: 'scan',
+        description: 'Scanne Sektor 30:30',
+        fulfilled: scanFulfilled,
+        targetX: 30,
+        targetY: 30,
+      },
+      {
+        type: 'scan_deliver',
+        description: 'Liefere die Daten zurück',
+        fulfilled: false,
+        stationX: 10,
+        stationY: 10,
+      },
+    ],
+  };
+}
+
+function makeCtx() {
+  return {
+    send: vi.fn(),
+    checkRate: vi.fn().mockReturnValue(true),
+    contributeToCommunityQuest: vi.fn(),
+    broadcast: vi.fn(),
+    _px: vi.fn().mockReturnValue(10),
+    _py: vi.fn().mockReturnValue(10),
+  };
+}
+
+function makeClient() {
+  return { sessionId: 's-1', auth: { userId: 'player-1' }, send: vi.fn() };
+}
+
+describe('checkQuestProgress — scan_deliver arrival offers turn-in', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends questTurnInOffer (not auto-complete) when arriving with scan done', async () => {
+    const row = reconQuestRow(true);
+    (getActiveQuests as any).mockResolvedValue([row]);
+    (getInventoryItem as any).mockResolvedValue(1); // slate present
+
+    const ctx = makeCtx();
+    const service = new QuestService(ctx as any);
+    await service.checkQuestProgress(makeClient() as any, 'player-1', 'arrive', {
+      sectorX: 10,
+      sectorY: 10,
+    });
+
+    const offerCall = (ctx.send as any).mock.calls.find((c: any[]) => c[1] === 'questTurnInOffer');
+    expect(offerCall).toBeDefined();
+    expect(offerCall[2]).toMatchObject({ questId: 'quest-1', title: 'Aufklärung Sektor 30:30' });
+    expect(offerCall[2].rewardCredits).toBe(150);
+
+    // Does NOT auto-complete and does NOT consume the slate.
+    expect(updateQuestStatus).not.toHaveBeenCalled();
+    expect(removeFromInventory).not.toHaveBeenCalled();
+    const completeCall = (ctx.send as any).mock.calls.find((c: any[]) => c[1] === 'questComplete');
+    expect(completeCall).toBeUndefined();
+    // The scan_deliver objective stays unfulfilled (not persisted as done).
+    const objSave = (updateQuestObjectives as any).mock.calls[0];
+    if (objSave) {
+      const saved = objSave[1];
+      expect(saved.find((o: any) => o.type === 'scan_deliver').fulfilled).toBe(false);
+    }
+  });
+
+  it('does nothing when arriving while the scan is NOT yet done', async () => {
+    const row = reconQuestRow(false);
+    (getActiveQuests as any).mockResolvedValue([row]);
+    (getInventoryItem as any).mockResolvedValue(0);
+
+    const ctx = makeCtx();
+    const service = new QuestService(ctx as any);
+    await service.checkQuestProgress(makeClient() as any, 'player-1', 'arrive', {
+      sectorX: 10,
+      sectorY: 10,
+    });
+
+    const offerCall = (ctx.send as any).mock.calls.find((c: any[]) => c[1] === 'questTurnInOffer');
+    expect(offerCall).toBeUndefined();
+    expect(updateQuestStatus).not.toHaveBeenCalled();
+    expect(removeFromInventory).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleTurnInQuest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('completes a ready quest at the giver station and consumes the slate', async () => {
+    const row = reconQuestRow(true);
+    (getQuestById as any).mockResolvedValue(row);
+    (getInventoryItem as any).mockResolvedValue(1); // slate present
+    (updateQuestStatus as any).mockResolvedValue(true);
+
+    const ctx = makeCtx();
+    const service = new QuestService(ctx as any);
+    await service.handleTurnInQuest(makeClient() as any, { questId: 'quest-1' });
+
+    // Slate consumed.
+    expect(removeFromInventory).toHaveBeenCalledWith('player-1', 'data_slate', 'quest-1', 1);
+    // Quest completed → status + reward + questComplete pushed.
+    expect(updateQuestStatus).toHaveBeenCalledWith('quest-1', 'completed');
+    expect(addCredits).toHaveBeenCalledWith('player-1', 150);
+    const completeCall = (ctx.send as any).mock.calls.find((c: any[]) => c[1] === 'questComplete');
+    expect(completeCall).toBeDefined();
+    expect(completeCall[2]).toMatchObject({ id: 'quest-1' });
+    // scan_deliver objective marked fulfilled + persisted.
+    const objSave = (updateQuestObjectives as any).mock.calls.find(
+      (c: any[]) => c[0] === 'quest-1',
+    );
+    expect(objSave).toBeDefined();
+    expect(objSave[1].find((o: any) => o.type === 'scan_deliver').fulfilled).toBe(true);
+  });
+
+  it('still completes when the data_slate is MISSING (robustness)', async () => {
+    const row = reconQuestRow(true);
+    (getQuestById as any).mockResolvedValue(row);
+    (getInventoryItem as any).mockResolvedValue(0); // slate gone
+    (updateQuestStatus as any).mockResolvedValue(true);
+
+    const ctx = makeCtx();
+    const service = new QuestService(ctx as any);
+    await service.handleTurnInQuest(makeClient() as any, { questId: 'quest-1' });
+
+    // Did not attempt to remove a non-existent slate.
+    expect(removeFromInventory).not.toHaveBeenCalled();
+    // But still completed.
+    expect(updateQuestStatus).toHaveBeenCalledWith('quest-1', 'completed');
+    const completeCall = (ctx.send as any).mock.calls.find((c: any[]) => c[1] === 'questComplete');
+    expect(completeCall).toBeDefined();
+  });
+
+  it('sends TURNIN_FAIL and does NOT complete when the scan is not yet done', async () => {
+    const row = reconQuestRow(false);
+    (getQuestById as any).mockResolvedValue(row);
+    (getInventoryItem as any).mockResolvedValue(0);
+
+    const ctx = makeCtx();
+    const service = new QuestService(ctx as any);
+    await service.handleTurnInQuest(makeClient() as any, { questId: 'quest-1' });
+
+    const errCall = (ctx.send as any).mock.calls.find(
+      (c: any[]) => c[1] === 'error' && c[2]?.code === 'TURNIN_FAIL',
+    );
+    expect(errCall).toBeDefined();
+    expect(updateQuestStatus).not.toHaveBeenCalled();
+  });
+
+  it('sends TURNIN_FAIL when not at the giver station', async () => {
+    const row = reconQuestRow(true);
+    (getQuestById as any).mockResolvedValue(row);
+    (getInventoryItem as any).mockResolvedValue(1);
+
+    const ctx = makeCtx();
+    // Player is somewhere else.
+    ctx._px.mockReturnValue(99);
+    ctx._py.mockReturnValue(99);
+    const service = new QuestService(ctx as any);
+    await service.handleTurnInQuest(makeClient() as any, { questId: 'quest-1' });
+
+    const errCall = (ctx.send as any).mock.calls.find(
+      (c: any[]) => c[1] === 'error' && c[2]?.code === 'TURNIN_FAIL',
+    );
+    expect(errCall).toBeDefined();
+    expect(updateQuestStatus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/rooms/SectorRoom.ts
+++ b/packages/server/src/rooms/SectorRoom.ts
@@ -730,6 +730,14 @@ export class SectorRoom extends Room<SectorRoomState> {
     this.onMessage('deliverQuest', async (client, data: { questId: string }) => {
       await this.quests.handleDeliverQuest(client, data.questId, this._px(client.sessionId), this._py(client.sessionId));
     });
+    this.onMessage('turnInQuest', async (client, data: { questId: string }) => {
+      try {
+        await this.quests.handleTurnInQuest(client, data ?? ({} as any));
+      } catch (err) {
+        logger.error({ err }, 'turnInQuest error');
+        client.send('error', { code: 'TURNIN_FAIL', message: 'Quest konnte nicht abgegeben werden' });
+      }
+    });
     this.onMessage('getReputation', async (client) => {
       await this.quests.handleGetReputation(client);
     });

--- a/packages/server/src/rooms/services/QuestService.ts
+++ b/packages/server/src/rooms/services/QuestService.ts
@@ -363,6 +363,68 @@ export class QuestService {
     await this.sendActiveQuests(client, auth.userId);
   }
 
+  // Player confirmed the turn-in offer (questTurnInOffer → turnInQuest). Verify
+  // the player is at the giver station with all scans done, robustly consume the
+  // data slate, and complete the quest via the shared completion path.
+  async handleTurnInQuest(client: Client, data: { questId: string }): Promise<void> {
+    const auth = client.auth as AuthPayload;
+    const row = await getQuestById(data.questId, auth.userId);
+
+    if (!row) {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Quest nicht gefunden' });
+      return;
+    }
+    if (row.status !== 'active') {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Quest nicht aktiv' });
+      return;
+    }
+
+    const objectives = row.objectives as QuestObjective[];
+    const deliverObj = objectives.find((o) => o.type === 'scan_deliver');
+    if (!deliverObj) {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Keine Abgabe für diese Quest' });
+      return;
+    }
+    if (deliverObj.fulfilled) {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Quest bereits abgeschlossen' });
+      return;
+    }
+
+    // Must be physically at the giver station.
+    const playerX = this.ctx._px(client.sessionId);
+    const playerY = this.ctx._py(client.sessionId);
+    if (deliverObj.stationX !== playerX || deliverObj.stationY !== playerY) {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Nicht an der Auftrags-Station' });
+      return;
+    }
+
+    // All non-(scan_deliver) objectives (i.e. the scan(s)) must be fulfilled.
+    const scansDone = objectives.filter((o) => o.type !== 'scan_deliver').every((o) => o.fulfilled);
+    if (!scansDone) {
+      this.ctx.send(client, 'error', { code: 'TURNIN_FAIL', message: 'Quest noch nicht abgeschlossen' });
+      return;
+    }
+
+    // Robustly consume the data slate — do NOT block completion if it is missing.
+    try {
+      const hasSlate = await getInventoryItem(auth.userId, 'data_slate', row.id);
+      if (hasSlate > 0) {
+        await removeFromInventory(auth.userId, 'data_slate', row.id, 1);
+      }
+    } catch {
+      /* ignore — slate may not exist */
+    }
+
+    deliverObj.fulfilled = true;
+    await updateQuestObjectives(row.id, objectives);
+    this.ctx.send(client, 'questProgress', { questId: row.id, objectives });
+
+    // Complete via the shared path (rewards granted + questComplete sent).
+    await this.completeQuest(client, auth.userId, row);
+    const updatedTracked = await getTrackedQuests(auth.userId);
+    this.ctx.send(client, 'trackedQuestsUpdate', { quests: updatedTracked });
+  }
+
   async handleGetTrackedQuests(client: Client): Promise<void> {
     const auth = client.auth as AuthPayload;
     const trackedQuests = await getTrackedQuests(auth.userId);
@@ -678,19 +740,29 @@ export class QuestService {
           }
         }
 
-        // scan_deliver: player returns data slate to quest station
+        // scan_deliver: player returns to quest station with scans done →
+        // OFFER turn-in instead of silently auto-completing. The client shows a
+        // popup; only when the player confirms (turnInQuest) does the quest
+        // complete via handleTurnInQuest. "Später" → re-offered on next arrival.
         if (
           obj.type === 'scan_deliver' &&
           action === 'arrive' &&
           obj.stationX === context.sectorX &&
           obj.stationY === context.sectorY
         ) {
-          const hasSlate = await getInventoryItem(playerId, 'data_slate', row.id);
-          if (hasSlate > 0) {
-            await removeFromInventory(playerId, 'data_slate', row.id, 1);
-            obj.fulfilled = true;
-            updated = true;
+          // Ready only when every OTHER objective (i.e. the scan(s)) is fulfilled.
+          const otherObjectivesDone = objectives
+            .filter((o) => o !== obj)
+            .every((o) => o.fulfilled);
+          if (otherObjectivesDone) {
+            const rewardCredits = (row.rewards as QuestRewards | undefined)?.credits;
+            this.ctx.send(client, 'questTurnInOffer', {
+              questId: row.id,
+              title: row.title ?? row.template_id,
+              ...(rewardCredits != null ? { rewardCredits } : {}),
+            });
           }
+          // Do NOT consume the slate, mark fulfilled, or complete here.
         }
 
         if (


### PR DESCRIPTION
Recon/scan quests now OFFER turn-in on return instead of silently auto-completing.

**Flow:** accept at 0:0 → "erforsche 7:1 + data slate" → fly → local scan (creates data_slate) → return to 0:0 → **offer popup** appears: **[QUEST ABSCHLIESSEN]** (turn in → rewards + completion popup) / **[SPÄTER]** (dismiss; quest stays open, re-offered next visit).

- Server: on arrival at the giver with scans done, sends `questTurnInOffer {questId,title,rewardCredits?}` (no auto-complete); new `turnInQuest {questId}` handler verifies + completes via the existing `completeQuest` path and **robustly** consumes the data_slate (no longer blocks if the slate is missing).
- Client: interactive `QuestTurnInOffer` modal; Abschließen → `turnInQuest`; Später → dismiss.

Tests: server +6 (1594 pass), client +4 (898 pass), server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)